### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
 
   test:


### PR DESCRIPTION
Potential fix for [https://github.com/fjacquet/epic_news/security/code-scanning/4](https://github.com/fjacquet/epic_news/security/code-scanning/4)

To fix the issue, we will add a `permissions` block to the workflow. Since the workflow primarily involves reading repository contents, setting up the environment, and uploading coverage reports, the minimal required permissions are `contents: read` and `actions: write`. These permissions will be added at the root level of the workflow to apply to all jobs, ensuring consistency and reducing the risk of privilege escalation.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
