### PR TITLE
chore(observability): instrument email send path with loguru

### DIFF
--- a/src/epic_news/crews/post/post_crew.py
+++ b/src/epic_news/crews/post/post_crew.py
@@ -1,10 +1,10 @@
-import logging
 from typing import Any, cast
 
 from crewai import Agent, Crew, Process, Task
 from crewai.project import CrewBase, agent, crew, task
 from crewai_tools import FileReadTool
 from dotenv import load_dotenv
+from loguru import logger
 
 from epic_news.config.llm_config import LLMConfig
 from epic_news.models.crews.post_result import PostResult
@@ -57,6 +57,7 @@ class PostCrew:
         Returns:
             List of Gmail send tools, or empty list if not available.
         """
+        logger.info("🔧 Loading Gmail send tools from Composio...")
         try:
             from epic_news.config.composio_config import ComposioConfig
 
@@ -71,8 +72,8 @@ class PostCrew:
             gmail_send_tools = [t for t in gmail_tools if any(n in t.name for n in send_tool_names)]
 
             if gmail_send_tools:
-                logging.getLogger(__name__).info(
-                    "Loaded {} Gmail send tools: {}",
+                logger.info(
+                    "✅ Loaded {} Gmail send tools: {}",
                     len(gmail_send_tools),
                     [t.name for t in gmail_send_tools],
                 )
@@ -82,17 +83,17 @@ class PostCrew:
             gmail_draft_tools = [t for t in gmail_tools if "GMAIL_CREATE_EMAIL_DRAFT" in t.name]
 
             if gmail_draft_tools:
-                logging.getLogger(__name__).warning(
-                    "GMAIL_SEND_EMAIL not returned, falling back to GMAIL_CREATE_EMAIL_DRAFT"
+                logger.warning(
+                    "⚠️ GMAIL_SEND_EMAIL not returned, falling back to GMAIL_CREATE_EMAIL_DRAFT (email will be a draft, not sent)"
                 )
                 return gmail_draft_tools
 
-            logging.getLogger(__name__).warning("No Gmail send/draft tools available")
+            logger.warning("⚠️ No Gmail send/draft tools available — email step will be a no-op")
             return []
 
         except Exception as e:
-            logging.getLogger(__name__).warning(
-                "Composio not available; email sending tools disabled. Reason: {}",
+            logger.warning(
+                "⚠️ Composio not available; email sending tools disabled. Reason: {}",
                 e,
             )
             return []

--- a/src/epic_news/main.py
+++ b/src/epic_news/main.py
@@ -1385,11 +1385,17 @@ class ReceptionFlow(Flow[ContentState]):
             # Use utility function to prepare all email parameters
             email_inputs = prepare_email_params(self.state)
 
-            # Log attachment status for better visibility
-            if email_inputs.get("attachment_path"):
-                print(f"📎 Using attachment: {email_inputs['attachment_path']}")
-            else:
-                print("⚠️ No valid attachment file found. Email will be sent without attachment.")
+            self.logger.info(
+                "✉️  Email payload: recipient={} subject={!r} attachment={} output_file={}",
+                email_inputs.get("recipient_email"),
+                email_inputs.get("subject"),
+                email_inputs.get("attachment_path") or "(none)",
+                email_inputs.get("output_file") or "(none)",
+            )
+            if not email_inputs.get("attachment_path"):
+                self.logger.warning(
+                    "📎 No valid attachment file found. Email will be sent without attachment."
+                )
 
             # If Composio isn't available, skip email sending gracefully
             try:
@@ -1409,13 +1415,34 @@ class ReceptionFlow(Flow[ContentState]):
                 # Instantiate and kickoff the PostCrew (kickoff-only)
                 post_crew = PostCrew()
                 email_result = kickoff_flow(post_crew, email_inputs)
-                print(f"📧 Email sending process initiated. Result: {email_result}")
+
+                # Parse the structured PostResult to log delivery outcome explicitly
+                post_result = getattr(email_result, "pydantic", None)
+                if post_result is not None:
+                    if getattr(post_result, "status", "") == "success":
+                        self.logger.info(
+                            "📨 PostResult: status=success recipient={} subject={!r} attachment_sent={}",
+                            post_result.recipient_email,
+                            post_result.subject,
+                            post_result.attachment_sent,
+                        )
+                    else:
+                        self.logger.error(
+                            "❌ PostResult: status=failure recipient={} error_message={}",
+                            getattr(post_result, "recipient_email", "?"),
+                            getattr(post_result, "error_message", "(none)"),
+                        )
+                else:
+                    raw = getattr(email_result, "raw", "") or ""
+                    self.logger.warning(
+                        "⚠️ PostResult absent — agent did not produce structured output. raw[:500]={!r}",
+                        raw[:500],
+                    )
                 self.state.email_sent = True  # Mark email as sent to prevent duplicates
             except Exception as e:
-                self.logger.error(f"❌ Error during email sending: {e}")
-                print(f"❌ Error during email sending: {e}")
+                self.logger.exception("❌ Error during email sending: {}", e)
         else:
-            print("📧 Email already sent for this request. Skipping.")
+            self.logger.info("📧 Email already sent for this request. Skipping.")
         return "send_email"  # Implicitly returns method name
 
 
@@ -1436,7 +1463,7 @@ def kickoff(user_input: str | None = None):
     request = (
         user_input
         if user_input
-        else "Fait moi un rapport PESTLE a propos de la societe Temenos aujourd'hui en français"
+        else "Fait moi un rapport PESTLE a propos de la societe  Mistral.AI aujourd'hui en français"
         # else "Complete OSINT analysis of Mistral.AI"
         # else "get the daily  news report"
         # else "conduct a deep research study on a travel on the north of the italy between san remo and Genova. Give me the best hotel and restaurant options."

--- a/src/epic_news/main.py
+++ b/src/epic_news/main.py
@@ -1461,9 +1461,8 @@ def kickoff(user_input: str | None = None):
     setup_logging()
     # If user_input is not provided, use a default value.
     request = (
-        user_input
-        if user_input
-        else "Fait moi un rapport PESTLE a propos de la societe  Mistral.AI aujourd'hui en français"
+        user_input if user_input else "get the rss weekly report"
+        # else "Fait moi un rapport PESTLE a propos de la societe  Mistral.AI aujourd'hui en français"
         # else "Complete OSINT analysis of Mistral.AI"
         # else "get the daily  news report"
         # else "conduct a deep research study on a travel on the north of the italy between san remo and Genova. Give me the best hotel and restaurant options."


### PR DESCRIPTION
## Summary

Replace stdlib `logging.getLogger()` calls in `post_crew.py` and bare `print()` calls in `ReceptionFlow.send_email` with **loguru**, and parse the structured `PostResult` returned by the PostCrew so the email delivery outcome lands in `logs/epic_news.log`.

## Why

A PESTEL run completed `send_email` without exception but no email arrived. The trace showed the task ran ~6 minutes, but `epic_news.log` went silent after `📬 Preparing to send email...` because:
- `post_crew.py` used `logging.getLogger(__name__)` — different sink, doesn't reach loguru file handler
- `main.py::send_email` used `print()` — stdout only, never logged

Without observability, impossible to diagnose whether the failure is in Composio, in the agent's tool choice, or in the email content.

## What changed

- **`src/epic_news/crews/post/post_crew.py`** — `import logging` → `from loguru import logger`; 4 stdlib log calls migrated; new `🔧 Loading Gmail send tools from Composio...` entry-point log.
- **`src/epic_news/main.py::send_email`** — `print()` → `self.logger.{info,warning}`; new `✉️  Email payload: ...` log before kickoff; new `📨 PostResult: status=success/failure ...` log after kickoff parsing `email_result.pydantic`; fallback log if `PostResult` absent.

## Expected new log shape

```
📬 Preparing to send email...
✉️  Email payload: recipient=fred@ljf.ch subject="..." attachment=output/pestel/report.html output_file=output/pestel/report.md
🔧 Loading Gmail send tools from Composio...
✅ Loaded 3 Gmail send tools: ['GMAIL_REPLY_TO_THREAD', 'GMAIL_SEND_DRAFT', 'GMAIL_SEND_EMAIL']
🚀 Kicking off crew PostCrew with context keys: attachment_path, body, ...
✅ Crew PostCrew finished in 369.42s
📨 PostResult: status=success recipient=fred@ljf.ch subject="..." attachment_sent=True
```

If the agent fails, we now see the exact `error_message` from `PostResult` instead of nothing.

## Test plan

- [x] `uv run pytest -q` — 556 passed, 5 skipped
- [x] `uv run ruff check` — clean
- [ ] Manual: run any flow that triggers `send_email`, then `tail -50 logs/epic_news.log` and verify the new lines appear
- [ ] Diagnose follow-up: based on `PostResult.status` + `error_message`, determine root cause of email non-delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced structured logging for email-sending workflows with improved visibility and error tracking.
  * Updated default query prompt used when no user input is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->