### PR TITLE
fix(deps): migrate to crewai-tools 1.x API after Dependabot bump

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "epic_news"
-version = "3.1.2"
+version = "3.1.3"
 description = "epic-news using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.13,<3.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
     "watchdog>=6.0.0",
     "apscheduler>=3.11.2",
     # --- Data sources / scraping ---
-    "beautifulsoup4>=4.14.3",
+    "beautifulsoup4>=4.13.4,<4.14",  # capped by crewai-tools>=1.14.3
     "lxml>=6.1.0",
     "lxml-html-clean>=0.4.2",
     "feedparser>=6.0.11",

--- a/scripts/update_knowledge_base.py
+++ b/scripts/update_knowledge_base.py
@@ -12,7 +12,7 @@ import yfinance as yf
 from crewai_tools import RagTool
 from loguru import logger
 
-from epic_news.rag_config import DEFAULT_RAG_CONFIG
+from epic_news.rag_config import build_rag_tool_kwargs
 from epic_news.tools.save_to_rag_tool import SaveToRagTool
 
 # Configure logging
@@ -29,12 +29,10 @@ def update_market_data(tickers: list[str], collection_suffix: str | None = None)
         collection_suffix: Optional suffix for the collection name
     """
     # Create RAG tools with the appropriate collection
-    config = DEFAULT_RAG_CONFIG.copy()
-    if collection_suffix:
-        config["vectordb"]["config"] = config["vectordb"]["config"].copy()
-        config["vectordb"]["config"]["collection_name"] = f"epic_news-{collection_suffix}"
-
-    rag_tool = RagTool(config=config, summarize=True)
+    rag_tool = RagTool(
+        **build_rag_tool_kwargs(collection_suffix=collection_suffix),
+        summarize=True,
+    )
     save_tool = SaveToRagTool(rag_tool=rag_tool)
 
     current_date = datetime.datetime.now().strftime("%Y-%m-%d")

--- a/src/epic_news/rag_config.py
+++ b/src/epic_news/rag_config.py
@@ -1,37 +1,67 @@
+"""Default RAG configuration for epic_news.
+
+The shape mirrors what ``crewai_tools.RagTool`` expects in 1.x — namely,
+``vectordb`` (provider + config) and ``embedding_model`` (provider + config).
+
+Persistence path: crewai-tools 1.x stores chromadb data under
+``appdirs.user_data_dir(<project_dir>, "CrewAI")`` by default. Override via the
+standard ``CREWAI_STORAGE_DIR`` env var rather than constructing a chromadb
+``Settings`` ourselves — pydantic v1↔v2 type validation between chromadb's v1
+``Settings`` and crewai's v2 ``ChromaDBConfig`` makes explicit overrides break
+at runtime.
+"""
+
 import os
+from typing import Any
 
 # Get the project root directory (2 levels up from this file)
 PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../.."))
 
-DEFAULT_RAG_CONFIG = {
-    "llm": {
-        "provider": "openrouter",  # Changed from openai to openrouter
-        "config": {
-            "model": os.getenv("MODEL", "openrouter/xiaomi/mimo-v2-flash:free"),
-            "api_key": os.getenv("OPENROUTER_API_KEY"),
-            "base_url": "https://openrouter.ai/api/v1",
-            "temperature": float(os.getenv("LLM_TEMPERATURE", "0.7")),
-            "max_tokens": 1000,
-        },
-    },
-    "embedder": {
-        "provider": "openai",  # Keep OpenAI for embeddings
-        "config": {
-            "model": "text-embedding-3-large",
-        },
-    },
+DEFAULT_COLLECTION_NAME = "finwiz"
+
+DEFAULT_RAG_CONFIG: dict[str, Any] = {
     "vectordb": {
-        "provider": "chroma",
+        "provider": "chromadb",
         "config": {
-            "collection_name": "finwiz",
-            "dir": os.path.join(PROJECT_ROOT, "db"),  # Absolute path to storage directory
-            "allow_reset": True,
+            "collection_name": DEFAULT_COLLECTION_NAME,
         },
     },
-    "chunker": {
-        "chunk_size": 400,
-        "chunk_overlap": 100,
-        "length_function": "len",
-        "min_chunk_size": 150,  # Must be greater than chunk_overlap
+    "embedding_model": {
+        "provider": "openai",
+        "config": {
+            "model_name": "text-embedding-3-large",
+        },
     },
 }
+
+
+def build_rag_tool_kwargs(
+    config: dict[str, Any] | None = None,
+    collection_suffix: str | None = None,
+) -> dict[str, Any]:
+    """Translate the project's RAG config into kwargs for ``RagTool(...)``.
+
+    crewai-tools 1.x makes ``collection_name`` a top-level ``RagTool`` arg
+    rather than a vectordb config field, so we pop it here.
+
+    Args:
+        config: Source config matching the shape of ``DEFAULT_RAG_CONFIG``.
+            Defaults to a deep copy of ``DEFAULT_RAG_CONFIG``.
+        collection_suffix: When provided, the collection becomes
+            ``epic_news-{suffix}`` so each crew gets its own slice.
+
+    Returns:
+        A dict suitable for ``RagTool(**kwargs)``.
+    """
+    import copy
+
+    src = copy.deepcopy(config if config is not None else DEFAULT_RAG_CONFIG)
+    vectordb = src.setdefault("vectordb", {"provider": "chromadb", "config": {}})
+    vdb_config: dict[str, Any] = vectordb.setdefault("config", {})
+
+    if collection_suffix:
+        vdb_config["collection_name"] = f"epic_news-{collection_suffix}"
+
+    collection_name: str = vdb_config.pop("collection_name", DEFAULT_COLLECTION_NAME)
+
+    return {"config": src, "collection_name": collection_name}

--- a/src/epic_news/tools/hybrid_search_tool.py
+++ b/src/epic_news/tools/hybrid_search_tool.py
@@ -146,7 +146,8 @@ class HybridSearchTool(BaseTool):
         if not results["success"] and self._brave_tool:
             try:
                 logger.info("Attempting Brave Search for: {}", search_query)
-                brave_result = self._brave_tool._run(search_query)
+                # crewai-tools 1.x: BraveSearchTool._run accepts only **kwargs.
+                brave_result = self._brave_tool._run(search_query=search_query)
                 brave_data = json.loads(brave_result)
 
                 if brave_data.get("success") and not brave_data.get("fallback_needed"):
@@ -166,7 +167,8 @@ class HybridSearchTool(BaseTool):
         if not results["success"] and self._serper_tool:
             try:
                 logger.info("Using SerperDev search for: {}", search_query)
-                serper_result = self._serper_tool._run(search_query)
+                # crewai-tools 1.x: SerperDevTool._run accepts only **kwargs.
+                serper_result = self._serper_tool._run(search_query=search_query)
                 if serper_result:
                     logger.info("SerperDev search successful")
                     results["sources_used"].append("serper_dev")
@@ -184,7 +186,7 @@ class HybridSearchTool(BaseTool):
         if not results["success"] and self._serper_news_tool:
             try:
                 logger.info("Trying news-specific search for: {}", search_query)
-                news_result = self._serper_news_tool._run(search_query)
+                news_result = self._serper_news_tool._run(search_query=search_query)
                 if news_result:
                     logger.info("News search successful")
                     results["sources_used"].append("serper_news")

--- a/src/epic_news/tools/rag_tools.py
+++ b/src/epic_news/tools/rag_tools.py
@@ -5,13 +5,10 @@ This module provides tools for Retrieval Augmented Generation (RAG)
 to enable crews to store and retrieve knowledge across sessions.
 """
 
-import copy  # Add import for deepcopy
-
 from crewai.tools import BaseTool as Tool
 from crewai_tools import RagTool
-from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
-from epic_news.rag_config import DEFAULT_RAG_CONFIG
+from epic_news.rag_config import build_rag_tool_kwargs
 from epic_news.tools.save_to_rag_tool import SaveToRagTool
 
 
@@ -26,31 +23,8 @@ def get_rag_tools(collection_suffix: str | None = None) -> list[Tool]:
     Returns:
         List of RAG tools for knowledge retrieval and storage.
     """
-    # Create a deep copy of the default config to prevent mutation
-    config = copy.deepcopy(DEFAULT_RAG_CONFIG)
-
-    # If a collection suffix is provided, create a crew-specific collection
-    if collection_suffix:
-        # No need to copy config["vectordb"]["config"] again as config is already a deepcopy
-        config["vectordb"]["config"]["collection_name"] = f"epic_news-{collection_suffix}"  # type: ignore[index]
-
-    # Instantiate the LLM and Embedder
-    llm = ChatOpenAI(**config["llm"]["config"])  # type: ignore[index]
-    embedder = OpenAIEmbeddings(**config["embedder"]["config"])  # type: ignore[index]
-
-    # Determine the collection name
-    collection_name = config["vectordb"]["config"]["collection_name"]  # type: ignore[index]
-
-    # Create the RAG tool for retrieval with app_config to ensure collection_name is properly set
     rag_tool = RagTool(
-        llm=llm,
-        embedder=embedder,
-        chunker_config=config["chunker"],
-        vectordb_config=config["vectordb"],
-        app_config={
-            "collection_name": collection_name,  # This ensures the collection name is properly set
-            "db": {"dir": config["vectordb"]["config"].get("dir", "/tmp/chroma_db")},  # type: ignore[index]
-        },
+        **build_rag_tool_kwargs(collection_suffix=collection_suffix),
         summarize=True,
         description=(
             "Use this tool to retrieve information from the epic_news knowledge base. "
@@ -59,7 +33,6 @@ def get_rag_tools(collection_suffix: str | None = None) -> list[Tool]:
         ),
     )
 
-    # Create the SaveToRag tool for storage
     save_to_rag_tool = SaveToRagTool(rag_tool=rag_tool)
 
     return [rag_tool, save_to_rag_tool]

--- a/src/epic_news/tools/save_to_rag_tool.py
+++ b/src/epic_news/tools/save_to_rag_tool.py
@@ -5,7 +5,7 @@ from crewai.tools import BaseTool
 from crewai_tools import RagTool
 from pydantic import BaseModel, Field
 
-from epic_news.rag_config import DEFAULT_RAG_CONFIG
+from epic_news.rag_config import build_rag_tool_kwargs
 
 
 class SaveToRagInput(BaseModel):
@@ -24,8 +24,9 @@ class SaveToRagTool(BaseTool):
 
     def __init__(self, rag_tool: RagTool | None = None) -> None:
         super().__init__()  # type: ignore[call-arg]
-        self._rag_tool = rag_tool or RagTool(config=DEFAULT_RAG_CONFIG, summarize=True)
+        self._rag_tool = rag_tool or RagTool(**build_rag_tool_kwargs(), summarize=True)
 
     def _run(self, text: str) -> str:
-        self._rag_tool.add(source=text, data_type="text")
+        # crewai-tools 1.x: source is positional; ``add()`` no longer accepts ``source=``.
+        self._rag_tool.add(text, data_type="text")
         return json.dumps({"status": "success", "message": "stored"})

--- a/src/epic_news/utils/html/template_renderers/company_news_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/company_news_renderer.py
@@ -7,6 +7,8 @@ Handles nested sections and articles as per reporting standards.
 
 from typing import Any
 
+from bs4 import Tag
+
 from .base_renderer import BaseRenderer
 
 
@@ -30,6 +32,8 @@ class CompanyNewsRenderer(BaseRenderer):
         if container is None:
             container = soup.new_tag("div", **{"class": "company-news-report"})  # type: ignore[arg-type]
             soup.append(container)
+        # bs4 4.13 stubs widen .find() to PageElement; narrow back to Tag for .append().
+        assert isinstance(container, Tag)
 
         # Add summary as header
         self._add_summary(soup, container, data)

--- a/src/epic_news/utils/html/template_renderers/osint_global_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/osint_global_renderer.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 from .base_renderer import BaseRenderer
 from .company_profiler_renderer import CompanyProfilerRenderer
@@ -245,7 +245,7 @@ class OSINTGlobalRenderer(BaseRenderer):
             sub_soup = BeautifulSoup(sub_content_html, "html.parser")
             # Find the main container and append its children
             main_div = sub_soup.find("div")
-            if main_div:
+            if isinstance(main_div, Tag):
                 # Clone the children to avoid modifying the original
                 for child in list(main_div.children):
                     # Skip the style tag as we have our own global styles

--- a/src/epic_news/utils/rss_weekly_converter.py
+++ b/src/epic_news/utils/rss_weekly_converter.py
@@ -3,7 +3,7 @@
 import re
 from datetime import datetime
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 
 from epic_news.models.crews.rss_weekly_report import RssWeeklyReport
 
@@ -24,16 +24,20 @@ def html_to_rss_weekly_json(html_content: str) -> dict:
     try:
         soup = BeautifulSoup(html_content, "html.parser")
 
-        # Extract title
+        # Extract title — bs4 4.13 stubs widen .find() to PageElement, so narrow to Tag.
         title_elem = soup.find("h1") or soup.find("title")
-        title = title_elem.get_text().strip() if title_elem else "Résumé Hebdomadaire des Flux RSS"
+        title = (
+            title_elem.get_text().strip()
+            if isinstance(title_elem, Tag)
+            else "Résumé Hebdomadaire des Flux RSS"
+        )
 
         # Extract executive summary
         summary = ""
         summary_section = soup.find("section", class_="executive-summary")
-        if summary_section:
+        if isinstance(summary_section, Tag):
             summary_p = summary_section.find("p")
-            if summary_p:
+            if isinstance(summary_p, Tag):
                 summary = summary_p.get_text().strip()
 
         # Extract feed digests
@@ -41,27 +45,35 @@ def html_to_rss_weekly_json(html_content: str) -> dict:
         feed_sections = soup.find_all("div", class_="feed-digest")
 
         for feed_section in feed_sections:
+            if not isinstance(feed_section, Tag):
+                continue
+
             # Extract feed name and URL
             feed_name_elem = feed_section.find("h3")
-            feed_name = feed_name_elem.get_text().strip() if feed_name_elem else "Source inconnue"
+            feed_name = (
+                feed_name_elem.get_text().strip() if isinstance(feed_name_elem, Tag) else "Source inconnue"
+            )
             # Remove emoji from feed name
             feed_name = re.sub(r"🌐\s*", "", feed_name)
 
             feed_url_elem = feed_section.find("a")
-            feed_url = feed_url_elem.get("href", "") if feed_url_elem else ""
+            feed_url = str(feed_url_elem.get("href", "")) if isinstance(feed_url_elem, Tag) else ""
 
             # Extract articles
             articles = []
             article_sections = feed_section.find_all("article", class_="article-summary")
 
             for article_section in article_sections:
+                if not isinstance(article_section, Tag):
+                    continue
+
                 # Extract article title and link
                 title_elem = article_section.find("h4")
-                if title_elem:
+                if isinstance(title_elem, Tag):
                     link_elem = title_elem.find("a")
-                    if link_elem:
+                    if isinstance(link_elem, Tag):
                         article_title = link_elem.get_text().strip()
-                        article_link = link_elem.get("href", "")
+                        article_link = str(link_elem.get("href", ""))
                     else:
                         article_title = title_elem.get_text().strip()
                         article_link = ""
@@ -71,16 +83,16 @@ def html_to_rss_weekly_json(html_content: str) -> dict:
 
                 # Extract published date
                 date_elem = article_section.find("p", class_="published-date")
-                published = date_elem.get_text().strip() if date_elem else ""
+                published = date_elem.get_text().strip() if isinstance(date_elem, Tag) else ""
                 # Remove emoji from date
                 published = re.sub(r"📅\s*", "", published)
 
                 # Extract summary
                 summary_elem = article_section.find("div", class_="summary")
                 article_summary = ""
-                if summary_elem:
+                if isinstance(summary_elem, Tag):
                     summary_p = summary_elem.find("p")
-                    if summary_p:
+                    if isinstance(summary_p, Tag):
                         article_summary = summary_p.get_text().strip()
 
                 articles.append(

--- a/tests/scripts/test_update_knowledge_base.py
+++ b/tests/scripts/test_update_knowledge_base.py
@@ -53,9 +53,8 @@ def test_update_market_data_success(
         tickers = ["AAPL"]
         update_market_data(tickers, collection_suffix="test-stocks")
 
-        # Verify RagTool was configured correctly
-        rag_config = mocks["rag_tool"].call_args.kwargs["config"]
-        assert rag_config["vectordb"]["config"]["collection_name"] == "epic_news-test-stocks"
+        # Verify RagTool was configured correctly — crewai-tools 1.x: top-level kwarg.
+        assert mocks["rag_tool"].call_args.kwargs["collection_name"] == "epic_news-test-stocks"
 
         # Verify SaveToRagTool was called with a valid knowledge entry
         mocks["save_tool"].return_value._run.assert_called_once()

--- a/tests/scripts/test_update_knowledge_base_script.py
+++ b/tests/scripts/test_update_knowledge_base_script.py
@@ -1,6 +1,6 @@
 from unittest.mock import call
 
-from epic_news.rag_config import DEFAULT_RAG_CONFIG
+from epic_news.rag_config import DEFAULT_COLLECTION_NAME
 from scripts.update_knowledge_base import main, prune_outdated_knowledge, update_market_data
 from tests.utils.context_managers import mock_knowledge_base_dependencies
 
@@ -52,10 +52,9 @@ def test_update_market_data_success(mocker):
         mocks["yf_ticker"].assert_any_call("AAPL")
         mocks["yf_ticker"].assert_any_call("MSFT")
 
-        # Assertions for RagTool instantiation
+        # Assertions for RagTool instantiation — crewai-tools 1.x: collection_name is top-level.
         mocks["rag_tool"].assert_called_once()
-        rag_config_arg = mocks["rag_tool"].call_args[1]["config"]
-        assert rag_config_arg["vectordb"]["config"]["collection_name"] == "epic_news-test_stocks"
+        assert mocks["rag_tool"].call_args.kwargs["collection_name"] == "epic_news-test_stocks"
 
         # Assertions for SaveToRagTool instantiation
         mocks["save_tool"].assert_called_once_with(rag_tool=mocks["rag_tool"].return_value)
@@ -96,12 +95,8 @@ def test_update_market_data_no_suffix(mocker):
         update_market_data(["AAPL"])
 
         mocks["rag_tool"].assert_called_once()
-        rag_config_arg = mocks["rag_tool"].call_args[1]["config"]
-        # Should use the default collection name from DEFAULT_RAG_CONFIG
-        assert (
-            rag_config_arg["vectordb"]["config"]["collection_name"]
-            == DEFAULT_RAG_CONFIG["vectordb"]["config"]["collection_name"]
-        )
+        # Should use the default collection name when no suffix is provided.
+        assert mocks["rag_tool"].call_args.kwargs["collection_name"] == DEFAULT_COLLECTION_NAME
         mocks["save_tool"].return_value._run.assert_called_once()
 
 

--- a/tests/test_rag_config.py
+++ b/tests/test_rag_config.py
@@ -1,31 +1,44 @@
 import os
 
-from epic_news.rag_config import DEFAULT_RAG_CONFIG, PROJECT_ROOT
+from epic_news.rag_config import (
+    DEFAULT_COLLECTION_NAME,
+    DEFAULT_RAG_CONFIG,
+    PROJECT_ROOT,
+    build_rag_tool_kwargs,
+)
 
 
 def test_default_rag_config_structure():
-    """Verify the structure and basic types of the RAG configuration."""
-    assert "llm" in DEFAULT_RAG_CONFIG
-    assert "embedder" in DEFAULT_RAG_CONFIG
-    assert "vectordb" in DEFAULT_RAG_CONFIG
-    assert "chunker" in DEFAULT_RAG_CONFIG
+    """Verify the structure matches crewai-tools 1.x ``RagToolConfig``."""
+    assert set(DEFAULT_RAG_CONFIG.keys()) == {"vectordb", "embedding_model"}
 
-    assert "provider" in DEFAULT_RAG_CONFIG["llm"]
-    assert "config" in DEFAULT_RAG_CONFIG["llm"]
+    vectordb = DEFAULT_RAG_CONFIG["vectordb"]
+    assert vectordb["provider"] == "chromadb"
+    assert vectordb["config"]["collection_name"] == DEFAULT_COLLECTION_NAME
 
-    assert "provider" in DEFAULT_RAG_CONFIG["embedder"]
-    assert "config" in DEFAULT_RAG_CONFIG["embedder"]
-
-    assert "provider" in DEFAULT_RAG_CONFIG["vectordb"]
-    assert "config" in DEFAULT_RAG_CONFIG["vectordb"]
-    assert "dir" in DEFAULT_RAG_CONFIG["vectordb"]["config"]
-    assert isinstance(DEFAULT_RAG_CONFIG["vectordb"]["config"]["dir"], str)
-
-    assert "chunk_size" in DEFAULT_RAG_CONFIG["chunker"]
-    assert isinstance(DEFAULT_RAG_CONFIG["chunker"]["chunk_size"], int)
+    embed = DEFAULT_RAG_CONFIG["embedding_model"]
+    assert embed["provider"] == "openai"
+    assert isinstance(embed["config"]["model_name"], str)
 
 
 def test_project_root_path():
     """Ensure the PROJECT_ROOT path is correctly calculated and points to the project root."""
-    # Check if a known file/directory at the root exists relative to PROJECT_ROOT
     assert os.path.exists(os.path.join(PROJECT_ROOT, "pyproject.toml"))
+
+
+def test_build_rag_tool_kwargs_default():
+    """Default build promotes ``collection_name`` to the top-level kwarg."""
+    kwargs = build_rag_tool_kwargs()
+    assert kwargs["collection_name"] == DEFAULT_COLLECTION_NAME
+
+    vdb_config = kwargs["config"]["vectordb"]["config"]
+    assert "collection_name" not in vdb_config  # promoted to top-level kwarg
+
+
+def test_build_rag_tool_kwargs_with_suffix():
+    """Suffix produces a crew-scoped collection name without mutating the source config."""
+    kwargs = build_rag_tool_kwargs(collection_suffix="stocks")
+    assert kwargs["collection_name"] == "epic_news-stocks"
+
+    # Source config remains pristine.
+    assert DEFAULT_RAG_CONFIG["vectordb"]["config"]["collection_name"] == DEFAULT_COLLECTION_NAME

--- a/tests/tools/test_rag_tools.py
+++ b/tests/tools/test_rag_tools.py
@@ -1,47 +1,32 @@
 import copy
+from typing import Any
 
 from crewai_tools import RagTool
 
 from epic_news.tools.rag_tools import get_rag_tools
 from epic_news.tools.save_to_rag_tool import SaveToRagTool
 
-# Make a deep copy of the original DEFAULT_RAG_CONFIG for testing
-# to avoid modifying the actual global config during tests.
-# We'll patch 'epic_news.tools.rag_tools.DEFAULT_RAG_CONFIG' to use this copy.
-# This structure should mirror epic_news.rag_config.DEFAULT_RAG_CONFIG
-TEST_DEFAULT_RAG_CONFIG = {
-    "llm": {
-        "provider": "openai",  # Using a common provider for tests
+# Mirror the production DEFAULT_RAG_CONFIG shape (crewai-tools 1.x).
+TEST_DEFAULT_RAG_CONFIG: dict[str, Any] = {
+    "vectordb": {
+        "provider": "chromadb",
         "config": {
-            "model": "gpt-3.5-turbo",  # Example model
+            "persist_directory": "/tmp/test_chroma_db",
+            "collection_name": "epic_news_default_collection",
         },
     },
-    "embedder": {
-        "provider": "openai",  # Using a common provider
+    "embedding_model": {
+        "provider": "openai",
         "config": {
-            "model": "text-embedding-ada-002",  # Key is 'model', not 'model_name'
+            "model_name": "text-embedding-ada-002",
         },
-    },
-    "vectordb": {  # Top-level key for vector database configuration
-        "provider": "chroma",
-        "config": {
-            "collection_name": "epic_news_default_collection",  # Test default collection name
-            "dir": "/tmp/test_chroma_db",  # Mocked path for tests
-            "allow_reset": True,
-        },
-    },
-    "chunker": {  # Adding chunker as it's in the actual config
-        "chunk_size": 500,
-        "chunk_overlap": 50,
-        "length_function": "len",
-        "min_chunk_size": 100,
     },
 }
 
 
 def test_get_rag_tools_no_suffix(mocker):
     mocker.patch(
-        "epic_news.tools.rag_tools.DEFAULT_RAG_CONFIG",
+        "epic_news.rag_config.DEFAULT_RAG_CONFIG",
         new_callable=lambda: copy.deepcopy(TEST_DEFAULT_RAG_CONFIG),
     )
     tools = get_rag_tools()
@@ -52,16 +37,17 @@ def test_get_rag_tools_no_suffix(mocker):
     # Test RagTool (retrieval)
     assert isinstance(retrieval_tool, RagTool)
     assert "retrieve information from the epic_news knowledge base" in retrieval_tool.description
-    assert retrieval_tool.summarize is True  # as per current implementation
+    assert retrieval_tool.summarize is True
+    assert retrieval_tool.collection_name == "epic_news_default_collection"
 
     # Test SaveToRagTool
     assert isinstance(save_tool, SaveToRagTool)
-    assert save_tool._rag_tool == retrieval_tool  # Check if it's the same instance
+    assert save_tool._rag_tool == retrieval_tool
 
 
 def test_get_rag_tools_with_suffix(mocker):
     mocker.patch(
-        "epic_news.tools.rag_tools.DEFAULT_RAG_CONFIG",
+        "epic_news.rag_config.DEFAULT_RAG_CONFIG",
         new_callable=lambda: copy.deepcopy(TEST_DEFAULT_RAG_CONFIG),
     )
     suffix = "test_crew"
@@ -73,6 +59,7 @@ def test_get_rag_tools_with_suffix(mocker):
     # Test RagTool (retrieval)
     assert isinstance(retrieval_tool, RagTool)
     assert "retrieve information from the epic_news knowledge base" in retrieval_tool.description
+    assert retrieval_tool.collection_name == f"epic_news-{suffix}"
 
     # Test SaveToRagTool
     assert isinstance(save_tool, SaveToRagTool)
@@ -81,23 +68,18 @@ def test_get_rag_tools_with_suffix(mocker):
 
 def test_default_rag_config_immutability(mocker):
     mocker.patch(
-        "epic_news.tools.rag_tools.DEFAULT_RAG_CONFIG",
+        "epic_news.rag_config.DEFAULT_RAG_CONFIG",
         new_callable=lambda: copy.deepcopy(TEST_DEFAULT_RAG_CONFIG),
     )
     original_collection_name = TEST_DEFAULT_RAG_CONFIG["vectordb"]["config"]["collection_name"]
 
-    # Call with a suffix, which should modify a copy
+    # Call with a suffix, which should not mutate the source config.
     get_rag_tools(collection_suffix="stocks")
-
-    # Assert that the mocked DEFAULT_RAG_CONFIG (our deep copy) was not changed by the call above
     assert TEST_DEFAULT_RAG_CONFIG["vectordb"]["config"]["collection_name"] == original_collection_name
 
-    # Call again without suffix - verify tools are created correctly
+    # Subsequent calls produce fresh tool instances.
     tools_no_suffix = get_rag_tools()
-    retrieval_tool_no_suffix = tools_no_suffix[0]
-    assert isinstance(retrieval_tool_no_suffix, RagTool)
+    assert isinstance(tools_no_suffix[0], RagTool)
 
-    # Call with another suffix - verify tools are created correctly
     tools_crypto_suffix = get_rag_tools(collection_suffix="crypto")
-    retrieval_tool_crypto_suffix = tools_crypto_suffix[0]
-    assert isinstance(retrieval_tool_crypto_suffix, RagTool)
+    assert isinstance(tools_crypto_suffix[0], RagTool)

--- a/tests/tools/test_save_to_rag_tool.py
+++ b/tests/tools/test_save_to_rag_tool.py
@@ -3,16 +3,7 @@ import json
 import pytest
 from crewai_tools import RagTool  # For type hinting and potentially mocking its instantiation
 
-# Assuming tests are run from the project root or 'src' is in PYTHONPATH
 from epic_news.tools.save_to_rag_tool import SaveToRagInput, SaveToRagTool
-
-# Mock DEFAULT_RAG_CONFIG as it's imported by save_to_rag_tool
-# We need to patch it where it's looked up by save_to_rag_tool
-MOCK_DEFAULT_RAG_CONFIG = {
-    "type": "chroma",
-    "db_path": "/tmp/mock_rag_db",
-    "collection_name": "mock_rag_collection",
-}
 
 
 @pytest.fixture
@@ -33,16 +24,20 @@ def test_save_to_rag_tool_instantiation_with_rag_tool(mock_rag_tool_instance):
 
 
 def test_save_to_rag_tool_instantiation_without_rag_tool(mocker):
-    """Test tool instantiation when no RagTool instance is provided,
-    so it creates its own."""
-    mocker.patch("epic_news.tools.save_to_rag_tool.DEFAULT_RAG_CONFIG", MOCK_DEFAULT_RAG_CONFIG)
+    """When no RagTool is provided, SaveToRagTool builds one from build_rag_tool_kwargs."""
+    mock_kwargs = {"config": {"vectordb": {"provider": "chromadb", "config": {}}}, "collection_name": "stub"}
+    mock_build = mocker.patch(
+        "epic_news.tools.save_to_rag_tool.build_rag_tool_kwargs",
+        return_value=mock_kwargs,
+    )
     mock_rag_tool_class = mocker.patch("epic_news.tools.save_to_rag_tool.RagTool")
-    mock_rag_instance = mock_rag_tool_class.return_value  # The instance RagTool() would return
+    mock_rag_instance = mock_rag_tool_class.return_value
     mock_rag_instance.add = mocker.MagicMock()
 
     tool = SaveToRagTool()
 
-    mock_rag_tool_class.assert_called_once_with(config=MOCK_DEFAULT_RAG_CONFIG, summarize=True)
+    mock_build.assert_called_once_with()
+    mock_rag_tool_class.assert_called_once_with(**mock_kwargs, summarize=True)
     assert tool._rag_tool == mock_rag_instance
     assert tool.name == "SaveToRag"
 
@@ -55,8 +50,8 @@ def test_save_to_rag_tool_run_success(mock_rag_tool_instance):
     result_json = tool._run(text=test_text)
     result = json.loads(result_json)
 
-    # Assert that the rag_tool's add method was called correctly
-    mock_rag_tool_instance.add.assert_called_once_with(source=test_text, data_type="text")
+    # crewai-tools 1.x: ``add()`` takes the source positionally.
+    mock_rag_tool_instance.add.assert_called_once_with(test_text, data_type="text")
 
     # Assert the expected JSON output
     assert result == {"status": "success", "message": "stored"}
@@ -70,5 +65,5 @@ def test_save_to_rag_tool_run_with_empty_text(mock_rag_tool_instance):
     result_json = tool._run(text=test_text)
     result = json.loads(result_json)
 
-    mock_rag_tool_instance.add.assert_called_once_with(source=test_text, data_type="text")
+    mock_rag_tool_instance.add.assert_called_once_with(test_text, data_type="text")
     assert result == {"status": "success", "message": "stored"}

--- a/uv.lock
+++ b/uv.lock
@@ -950,7 +950,7 @@ wheels = [
 
 [[package]]
 name = "epic-news"
-version = "3.1.2"
+version = "3.1.3"
 source = { editable = "." }
 dependencies = [
     { name = "apscheduler" },

--- a/uv.lock
+++ b/uv.lock
@@ -295,15 +295,15 @@ wheels = [
 
 [[package]]
 name = "beautifulsoup4"
-version = "4.14.3"
+version = "4.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "soupsieve" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/2e/3e5079847e653b1f6dc647aa24549d68c6addb4c595cc0d902d1b19308ad/beautifulsoup4-4.13.5.tar.gz", hash = "sha256:5e70131382930e7c3de33450a2f54a63d5e4b19386eab43a5b34d594268f3695", size = 622954, upload-time = "2025-08-24T14:06:13.168Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+    { url = "https://files.pythonhosted.org/packages/04/eb/f4151e0c7377a6e08a38108609ba5cede57986802757848688aeedd1b9e8/beautifulsoup4-4.13.5-py3-none-any.whl", hash = "sha256:642085eaa22233aceadff9c69651bc51e8bf3f874fb6d7104ece2beb24b47c4a", size = 105113, upload-time = "2025-08-24T14:06:14.884Z" },
 ]
 
 [[package]]
@@ -702,24 +702,21 @@ wheels = [
 
 [[package]]
 name = "crewai-tools"
-version = "0.76.0"
+version = "1.14.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "crewai" },
-    { name = "docker" },
-    { name = "lancedb" },
-    { name = "pypdf" },
+    { name = "pymupdf" },
     { name = "python-docx" },
     { name = "pytube" },
     { name = "requests" },
-    { name = "stagehand" },
     { name = "tiktoken" },
     { name = "youtube-transcript-api" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a8/4c/b33d8aaedf1b0c059545ce642a2238e67f1d3c15c5f20fb659a5e4f511ae/crewai_tools-0.76.0.tar.gz", hash = "sha256:5511b21387ad5366564e04d2b3ef7f951d423d9550f880c92a11fec340c624f3", size = 1137089, upload-time = "2025-10-08T21:21:21.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/ea/97b6a0e61b2117f9bd2dc9adf1af1f190cd5e69cebf10c5f4fe51d5c82af/crewai_tools-1.14.4.tar.gz", hash = "sha256:fe257e63a6fbc80f834543e033b2e5799446e32d471177397496d44d73a5a7d6", size = 896834, upload-time = "2026-04-30T19:12:46.114Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ab/a9/7bb9aba01e2f98a8328b2d4d97c1adc647235c34caaafd93617eb14a53a7/crewai_tools-0.76.0-py3-none-any.whl", hash = "sha256:9d6b42e6ff627262e8f53dfa92cdc955dbdb354082fd90b209f65fdfe1d2b639", size = 741046, upload-time = "2025-10-08T21:21:19.947Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/3d/e6a15b9521b3127a1716fa56e83b65274b661871cd2d611c3655d54a8301/crewai_tools-1.14.4-py3-none-any.whl", hash = "sha256:675af68f85b4a8c5d958767d408970a30f3c19f2f8b727fb63ef72e649ea5970", size = 811057, upload-time = "2026-04-30T19:12:43.668Z" },
 ]
 
 [package.optional-dependencies]
@@ -900,20 +897,6 @@ wheels = [
 ]
 
 [[package]]
-name = "docker"
-version = "7.1.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pywin32", marker = "sys_platform == 'win32'" },
-    { name = "requests" },
-    { name = "urllib3" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/91/9b/4a2ea29aeba62471211598dac5d96825bb49348fa07e906ea930394a83ce/docker-7.1.0.tar.gz", hash = "sha256:ad8c70e6e3f8926cb8a92619b832b4ea5299e2831c14284663184e200546fa6c", size = 117834, upload-time = "2024-05-23T11:13:57.216Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/26/57c6fb270950d476074c087527a558ccb6f4436657314bfb6cdf484114c4/docker-7.1.0-py3-none-any.whl", hash = "sha256:c96b93b7f0a746f9e77d325bcfb87422a3d8bd4f03136ae8a85b37f1898d5fc0", size = 147774, upload-time = "2024-05-23T11:13:55.01Z" },
-]
-
-[[package]]
 name = "docstring-parser"
 version = "0.18.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1055,7 +1038,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "apscheduler", specifier = ">=3.11.2" },
-    { name = "beautifulsoup4", specifier = ">=4.14.3" },
+    { name = "beautifulsoup4", specifier = ">=4.13.4,<4.14" },
     { name = "chromadb", specifier = ">=0.5.23" },
     { name = "composio", specifier = ">=0.1.1" },
     { name = "composio-crewai", specifier = ">=0.7.18" },
@@ -3440,6 +3423,21 @@ crypto = [
 ]
 
 [[package]]
+name = "pymupdf"
+version = "1.26.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/48/d6/09b28f027b510838559f7748807192149c419b30cb90e6d5f0cf916dc9dc/pymupdf-1.26.7.tar.gz", hash = "sha256:71add8bdc8eb1aaa207c69a13400693f06ad9b927bea976f5d5ab9df0bb489c3", size = 84327033, upload-time = "2025-12-11T21:48:50.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/35/cd74cea1787b2247702ef8522186bdef32e9cb30a099e6bb864627ef6045/pymupdf-1.26.7-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:07085718dfdae5ab83b05eb5eb397f863bcc538fe05135318a01ea353e7a1353", size = 23179369, upload-time = "2025-12-11T21:47:21.587Z" },
+    { url = "https://files.pythonhosted.org/packages/72/74/448b6172927c829c6a3fba80078d7b0a016ebbe2c9ee528821f5ea21677a/pymupdf-1.26.7-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:31aa9c8377ea1eea02934b92f4dcf79fb2abba0bf41f8a46d64c3e31546a3c02", size = 22470101, upload-time = "2025-12-11T21:47:37.105Z" },
+    { url = "https://files.pythonhosted.org/packages/65/e7/47af26f3ac76be7ac3dd4d6cc7ee105948a8355d774e5ca39857bf91c11c/pymupdf-1.26.7-cp310-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e419b609996434a14a80fa060adec72c434a1cca6a511ec54db9841bc5d51b3c", size = 23502486, upload-time = "2025-12-12T09:51:25.824Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/6b/3de1714d734ff949be1e90a22375d0598d3540b22ae73eb85c2d7d1f36a9/pymupdf-1.26.7-cp310-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:69dfc78f206a96e5b3ac22741263ebab945fdf51f0dbe7c5757c3511b23d9d72", size = 24115727, upload-time = "2025-12-11T21:47:51.274Z" },
+    { url = "https://files.pythonhosted.org/packages/62/9b/f86224847949577a523be2207315ae0fd3155b5d909cd66c274d095349a3/pymupdf-1.26.7-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1d5106f46e1ca0d64d46bd51892372a4f82076bdc14a9678d33d630702abca36", size = 24324386, upload-time = "2025-12-12T14:58:45.483Z" },
+    { url = "https://files.pythonhosted.org/packages/85/8e/a117d39092ca645fde8b903f4a941d9aa75b370a67b4f1f435f56393dc5a/pymupdf-1.26.7-cp310-abi3-win32.whl", hash = "sha256:7c9645b6f5452629c747690190350213d3e5bbdb6b2eca227d82702b327f6eee", size = 17203888, upload-time = "2025-12-12T13:59:57.613Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/c3/d0047678146c294469c33bae167c8ace337deafb736b0bf97b9bc481aa65/pymupdf-1.26.7-cp310-abi3-win_amd64.whl", hash = "sha256:425b1befe40d41b72eb0fe211711c7ae334db5eb60307e9dd09066ed060cceba", size = 18405952, upload-time = "2025-12-11T21:48:02.947Z" },
+]
+
+[[package]]
 name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -3469,15 +3467,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
-]
-
-[[package]]
-name = "pypdf"
-version = "6.10.2"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/7b/3f/9f2167401c2e94833ca3b69535bad89e533b5de75fefe4197a2c224baec2/pypdf-6.10.2.tar.gz", hash = "sha256:7d09ce108eff6bf67465d461b6ef352dcb8d84f7a91befc02f904455c6eea11d", size = 5315679, upload-time = "2026-04-15T16:37:36.978Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/d6/1d5c60cc17bbdf37c1552d9c03862fc6d32c5836732a0415b2d637edc2d0/pypdf-6.10.2-py3-none-any.whl", hash = "sha256:aa53be9826655b51c96741e5d7983ca224d898ac0a77896e64636810517624aa", size = 336308, upload-time = "2026-04-15T16:37:34.851Z" },
 ]
 
 [[package]]
@@ -4246,26 +4235,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/38/82/10cdfab4ab663a6b6bd624d33f55b2cfa41af5105be033a6d5d135a92c5f/sse_starlette-3.4.2.tar.gz", hash = "sha256:2f9a7f51ed84395a0427fb9f66cb1ec11f7899d977a72cbc9070b962a2e14489", size = 35236, upload-time = "2026-05-06T19:42:13.727Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/27/351c71e803c56090d8d3bf9520422debeb8ed938871fd4f7ef519805a6c5/sse_starlette-3.4.2-py3-none-any.whl", hash = "sha256:6ea5d35b7ce979a3de5a0db5f77fe886b1616e4b3e1ad93fba502bd9b5fb662f", size = 16516, upload-time = "2026-05-06T19:42:12.201Z" },
-]
-
-[[package]]
-name = "stagehand"
-version = "3.20.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-    { name = "distro" },
-    { name = "httpx" },
-    { name = "pydantic" },
-    { name = "sniffio" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/1b/f703463a04a227f10c19a1f79c0311597a7a374ad02065e2294eb54ebaef/stagehand-3.20.0.tar.gz", hash = "sha256:c862f2da2ed0ed958ca5c8aec743bcfecf4a944336cf30df68a715f1c18a4abb", size = 283951, upload-time = "2026-05-07T16:20:56.439Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/bf/a000e0d54009831e099a3d8dd0277ad638a15d0b4ead3a7d32d75677508b/stagehand-3.20.0-py3-none-macosx_10_9_x86_64.whl", hash = "sha256:03a9dbd4b5952106e0685d51c6879a14306d3172367400daee4954c0581e2e54", size = 34504378, upload-time = "2026-05-07T16:21:08.789Z" },
-    { url = "https://files.pythonhosted.org/packages/22/b7/bab837635ed381e5f1f3fbfa9636ec2670ca71727b720d4a00c69aebb46e/stagehand-3.20.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:72943f6056b0554770c54dabbce62ad9da1eb24ca1bf70da312e63a0802881c7", size = 33202451, upload-time = "2026-05-07T16:20:58.701Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/5b/eb9623fa7e8627ed74b8f3f90e4076d29fb41531108b5141a966f9ff4a5f/stagehand-3.20.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:69cecb87b9f672e435f7297ab96dd6e81f23a4ec65bf0e5c00ce66a6b4601965", size = 37282736, upload-time = "2026-05-07T16:21:02.373Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/32/8140daf343c9c150bc88a96d82c4540b6ae1f96c5cb0d4d89fcc1c438426/stagehand-3.20.0-py3-none-win_amd64.whl", hash = "sha256:110f231246847220e3e5fc06565042e6024e5fdc7094e4f6dd0328c63abd4c94", size = 30771429, upload-time = "2026-05-07T16:21:05.648Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Yesterday's Dependabot merges (PR #90 `crewai-tools[mcp] 0.47→1.14` + PR #89 `beautifulsoup4 → 4.14`) were individually green but **collectively unresolvable** — `crewai-tools 1.x` carries a hard cap `bs4>=4.13.4,<4.14`, and the major bump also reshaped the `RagTool` / `BraveSearchTool` / `SerperDevTool` APIs.

CI on `main` would currently fail mypy with 23 errors. This PR collapses both bumps into a working state.

## Changes

### Dependency
- `beautifulsoup4>=4.13.4,<4.14` (transitive cap from `crewai-tools` 1.x).

### `RagTool` migration (1.x)
- `rag_config.py`: drop legacy embedchain shape (`llm`/`embedder`/`chunker`/`app_config`). New shape uses only `vectordb` + `embedding_model` per `RagToolConfig`. Add `build_rag_tool_kwargs()` helper that promotes `collection_name` to the top-level `RagTool` kwarg (where it now lives).
- `tools/rag_tools.py`, `tools/save_to_rag_tool.py`, `scripts/update_knowledge_base.py`: use new helper; `add()` takes source positionally (`source=` kwarg removed in 1.x).

### Search-tool signatures
- `tools/hybrid_search_tool.py`: `BraveSearchTool._run` and `SerperDevTool._run` now declare `**kwargs` only — switched call sites to `_run(search_query=...)`.

### bs4 4.13 typing
The recent `ec91605` cleanup removed `# type: ignore` comments assuming bs4 4.14 stubs. With the cap back to 4.13, those errors return. Replaced with proper `isinstance(elem, Tag)` narrowing in:
- `utils/rss_weekly_converter.py`
- `utils/html/template_renderers/company_news_renderer.py`
- `utils/html/template_renderers/osint_global_renderer.py`

### Tests
Updated fixtures and assertions in 5 test files to the new API (positional `add()`, top-level `collection_name`, new config shape).

## Behavioral note

Chromadb persistence path moves from `<project>/db` to crewai's default appdirs location (`~/Library/Application Support/CrewAI/<project>` on macOS). Override via the standard `CREWAI_STORAGE_DIR` env var. Previous scratchpad data won't migrate — this matches crewai 1.x conventions and per the architecture docs RAG is a short-term scratchpad, not durable knowledge.

The pydantic v1 (chromadb `Settings`) ↔ v2 (crewai `ChromaDBConfig`) interaction breaks if we construct an explicit `Settings` ourselves, so we let crewai own the path. Documented in `rag_config.py`.

## Verification

```
ruff check --fix .   → All checks passed!
mypy src/epic_news   → Success: no issues found in 224 source files
pytest -q            → 560 passed, 5 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated BeautifulSoup4 dependency constraint.

* **Bug Fixes**
  * Improved robustness of HTML element extraction and parsing across news rendering and RSS conversion workflows.
  * Enhanced type safety in HTML document handling to prevent extraction errors.

* **Refactor**
  * Updated RAG tool configuration and invocation methods for improved framework compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->