### PR TITLE
fix(rag): apply CodeRabbit feedback from PR #93

### DIFF
--- a/src/epic_news/rag_config.py
+++ b/src/epic_news/rag_config.py
@@ -11,6 +11,7 @@ standard ``CREWAI_STORAGE_DIR`` env var rather than constructing a chromadb
 at runtime.
 """
 
+import copy
 import os
 from typing import Any
 
@@ -53,8 +54,6 @@ def build_rag_tool_kwargs(
     Returns:
         A dict suitable for ``RagTool(**kwargs)``.
     """
-    import copy
-
     src = copy.deepcopy(config if config is not None else DEFAULT_RAG_CONFIG)
     vectordb = src.setdefault("vectordb", {"provider": "chromadb", "config": {}})
     vdb_config: dict[str, Any] = vectordb.setdefault("config", {})

--- a/src/epic_news/tools/save_to_rag_tool.py
+++ b/src/epic_news/tools/save_to_rag_tool.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 from crewai.tools import BaseTool
@@ -6,6 +5,7 @@ from crewai_tools import RagTool
 from pydantic import BaseModel, Field
 
 from epic_news.rag_config import build_rag_tool_kwargs
+from epic_news.tools._json_utils import ensure_json_str
 
 
 class SaveToRagInput(BaseModel):
@@ -28,5 +28,8 @@ class SaveToRagTool(BaseTool):
 
     def _run(self, text: str) -> str:
         # crewai-tools 1.x: source is positional; ``add()`` no longer accepts ``source=``.
-        self._rag_tool.add(text, data_type="text")
-        return json.dumps({"status": "success", "message": "stored"})
+        try:
+            self._rag_tool.add(text, data_type="text")
+        except Exception as exc:
+            return ensure_json_str({"status": "error", "message": str(exc)})
+        return ensure_json_str({"status": "success", "message": "stored"})

--- a/tests/tools/test_rag_tools.py
+++ b/tests/tools/test_rag_tools.py
@@ -11,7 +11,6 @@ TEST_DEFAULT_RAG_CONFIG: dict[str, Any] = {
     "vectordb": {
         "provider": "chromadb",
         "config": {
-            "persist_directory": "/tmp/test_chroma_db",
             "collection_name": "epic_news_default_collection",
         },
     },


### PR DESCRIPTION
Follow-up to #93. The original PR was merged before these 4 review fixes were included; this lifts them onto main as a separate, minimal change.

## Changes

- **save_to_rag_tool._run**: wrap `add()` in try/except and return JSON via `ensure_json_str`. Failures now surface as `{"status":"error","message":...}` instead of unhandled exceptions, matching the project convention that all `_run()` methods return JSON strings.
- **test_rag_tools**: drop hardcoded `/tmp/test_chroma_db` (Ruff S108) by removing `persist_directory` from the test fixture — the production `DEFAULT_RAG_CONFIG` no longer carries that key, so the test was already drift.
- **rag_config**: hoist `import copy` to module scope (CodeRabbit nit).

## Deferred

CodeRabbit also flagged `scripts/update_knowledge_base.py` for using RAG scratchpad tools as a persistent KB. That's pre-existing architectural debt that long predates the 1.x migration — keeping it out of this PR.

## Verification

```
ruff check         → All checks passed!
mypy src/epic_news → Success: no issues found in 224 source files
pytest -q          → 560 passed, 5 skipped
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)