### PR TITLE
fix: type errors from requests 2.34 stricter stubs (unbreaks main CI)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "unidecode>=1.4.0",
     # --- HTTP / Web ---
-    "requests>=2.33.0",
+    "requests>=2.34.0",
     "requests-cache>=1.3.2",
     "httpx>=0.27.2",
     "fastapi>=0.115.13",

--- a/src/epic_news/tools/coinmarketcap_list_tool.py
+++ b/src/epic_news/tools/coinmarketcap_list_tool.py
@@ -66,7 +66,7 @@ class CoinMarketCapListTool(BaseTool):
                 "X-CMC_PRO_API_KEY": os.environ.get("X-CMC_PRO_API_KEY", ""),
                 "Accept": "application/json",
             }
-            params = {"limit": limit, "sort": sort_by, "convert": "USD"}
+            params: dict[str, str | int] = {"limit": limit, "sort": sort_by, "convert": "USD"}
 
             response = requests.get(
                 f"{CMC_BASE_URL}/cryptocurrency/listings/latest",

--- a/src/epic_news/tools/coinmarketcap_news_tool.py
+++ b/src/epic_news/tools/coinmarketcap_news_tool.py
@@ -39,7 +39,7 @@ class CoinMarketCapNewsTool(BaseTool):
             }
 
             api_endpoint = f"{CMC_PRO_API_BASE_URL}/v2/news/latest"
-            params = {"limit": limit, "sort_by": "published_at"}
+            params: dict[str, str | int] = {"limit": limit, "sort_by": "published_at"}
 
             if symbol:
                 if symbol.islower() and "-" in symbol or (symbol.islower() and not symbol.isupper()):

--- a/src/epic_news/tools/geoapify_places_tool.py
+++ b/src/epic_news/tools/geoapify_places_tool.py
@@ -162,7 +162,11 @@ class GeoapifyPlacesTool(BaseTool):
             return json.dumps({"error": "GEOAPIFY_API_KEY environment variable not set"})
 
         # Build query parameters
-        query_params = {"apiKey": api_key, "limit": params.limit, "lang": params.lang}
+        query_params: dict[str, str | int] = {
+            "apiKey": api_key,
+            "limit": params.limit,
+            "lang": params.lang,
+        }
 
         # Add categories if provided
         if params.categories:

--- a/src/epic_news/tools/scrape_ninja_tool.py
+++ b/src/epic_news/tools/scrape_ninja_tool.py
@@ -43,10 +43,14 @@ class ScrapeNinjaTool(BaseTool):
         """Scrape a website using ScrapeNinja API with advanced options"""
         api_url = "https://scrapeninja.p.rapidapi.com/scrape"
 
+        api_key = self.api_key
+        if api_key is None:
+            return json.dumps({"error": "RAPIDAPI_KEY environment variable not set"})
+
         headers = {
             "Content-Type": "application/json",
             "Accept": "*/*",
-            "X-RapidAPI-Key": self.api_key,
+            "X-RapidAPI-Key": api_key,
             "X-RapidAPI-Host": "scrapeninja.p.rapidapi.com",
         }
 

--- a/uv.lock
+++ b/uv.lock
@@ -1018,7 +1018,7 @@ requires-dist = [
     { name = "pytest-regressions", marker = "extra == 'test'", specifier = ">=2.10.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
-    { name = "requests", specifier = ">=2.33.0" },
+    { name = "requests", specifier = ">=2.34.0" },
     { name = "requests-cache", specifier = ">=1.3.2" },
     { name = "streamlit", specifier = ">=1.46.0" },
     { name = "tavily-python", specifier = ">=0.7.24" },


### PR DESCRIPTION
## Why

Merging the Dependabot bumps (#100 requests-cache, #101 crewai-tools) transitively relocked **requests to 2.34.2** in `uv.lock`. requests 2.34 ships stricter type stubs, which surface 4 pre-existing `mypy` arg-type errors. As a result **`main` CI is currently failing** at the mypy step.

Dependabot auto-closed #97 (the explicit `requests` bump) as "up-to-date" since the lock already satisfies it — but the type fixes it would have needed were never applied. This PR delivers that fix.

## What

- `scrape_ninja_tool.py`: narrow `api_key` (`str | None`) to `str` before building the headers dict
- `geoapify_places_tool.py`, `coinmarketcap_news_tool.py`, `coinmarketcap_list_tool.py`: annotate the `params`/`query_params` dicts as `dict[str, str | int]` so values satisfy `requests.get/post` signatures
- `pyproject.toml`: bump constraint to `requests>=2.34.0` to match the locked reality (was #97's intent)

## Verification (local)

- `uv run mypy src/epic_news` → no issues (222 files)
- `uv run ruff check .` → all checks passed
- `uv run pytest` → 554 passed, 5 skipped
- semgrep scan of changed files → 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)