### PR TITLE
Lean dependencies + official secured SBOM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,25 @@
-# enable the best to stay up to date
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
+---
+# Dependabot: grouped, capped updates to minimise upgrade-chore noise.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-
 version: 2
 updates:
-  - package-ecosystem: "uv"  # Python dependency updates via uv
-    directory: "/"  # Location of package manifests
+  - package-ecosystem: "uv"
+    directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -39,12 +39,15 @@ jobs:
       - name: Dependency hygiene audit (deptry)
         run: make deps-audit
 
-      - name: Install osv-scanner (pinned)
+      - name: Install osv-scanner (pinned, checksum-verified)
         run: |
-          curl -sSL \
-            https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64 \
-            -o osv-scanner
-          chmod +x osv-scanner
+          VERSION=v2.3.8
+          BASE="https://github.com/google/osv-scanner/releases/download/${VERSION}"
+          curl -sSL "${BASE}/osv-scanner_linux_amd64" -o osv-scanner_linux_amd64
+          curl -sSL "${BASE}/osv-scanner_SHA256SUMS" -o osv-scanner_SHA256SUMS
+          grep " osv-scanner_linux_amd64$" osv-scanner_SHA256SUMS | sha256sum -c -
+          chmod +x osv-scanner_linux_amd64
+          mv osv-scanner_linux_amd64 osv-scanner
           ./osv-scanner --version
 
       - name: Vulnerability scan (blocking, honors allowlist)

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,9 +21,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
 
@@ -55,7 +57,7 @@ jobs:
 
       - name: Upload SBOM artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sbom-cyclonedx
           path: sbom.cdx.json
@@ -71,9 +73,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,89 @@
+---
+name: Security & SBOM
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    tags: ["v*"]
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC — catch newly-disclosed CVEs
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom-and-scan:
+    name: SBOM + vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Sync dependencies (locked)
+        run: uv sync --all-extras --locked
+
+      - name: Generate CycloneDX SBOM
+        run: make sbom
+
+      - name: Dependency hygiene audit (deptry)
+        run: make deps-audit
+
+      - name: Install osv-scanner (pinned)
+        run: |
+          curl -sSL \
+            https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64 \
+            -o osv-scanner
+          chmod +x osv-scanner
+          ./osv-scanner --version
+
+      - name: Vulnerability scan (blocking, honors allowlist)
+        run: ./osv-scanner scan source -L sbom.cdx.json --config=osv-scanner.toml
+
+      - name: Upload SBOM artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          if-no-files-found: error
+
+  publish-sbom:
+    name: Attach SBOM to GitHub Release
+    needs: sbom-and-scan
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Generate CycloneDX SBOM
+        run: make sbom
+
+      - name: Upload SBOM to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 \
+            || gh release create "${GITHUB_REF_NAME}" --generate-notes
+          gh release upload "${GITHUB_REF_NAME}" sbom.cdx.json --clobber

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,7 @@ quality-report.md
 # Project-specific directories (uncomment if not needed)
 # @/
 site/
+
+# Generated SBOM artifacts (produced fresh in CI / on demand)
+sbom.cdx.json
+sbom-requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ install: ## Install production dependencies
 	uv pip install -e .
 	@echo "$(GREEN)✓ Production dependencies installed$(RESET)"
 
-dev: ## Install development dependencies (includes mypy, bandit, safety)
+dev: ## Install development dependencies (includes mypy, bandit, deptry)
 	@echo "$(GREEN)Installing development dependencies...$(RESET)"
 	uv sync --all-extras --locked
 	uv pip install -e .

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ sbom: ## Generate a CycloneDX SBOM (sbom.cdx.json) from the uv lockfile
 	@rm -f sbom-requirements.txt
 	@echo "$(GREEN)✓ sbom.cdx.json generated$(RESET)"
 
-security: ## Run security checks (bandit + safety)
+security: sbom ## Run security checks (bandit + osv-scanner against the SBOM)
 	@echo "$(GREEN)Checking for security issues in code...$(RESET)"
 	@if uv run python -c "import bandit" 2>/dev/null; then \
 		uv run bandit -r $(SRC_DIR) -f json -o bandit-report.json || true; \
@@ -135,12 +135,12 @@ security: ## Run security checks (bandit + safety)
 		echo "$(YELLOW)⚠ bandit not installed. Install with: uv add --dev bandit$(RESET)"; \
 	fi
 	@echo ""
-	@echo "$(GREEN)Checking for vulnerable dependencies...$(RESET)"
-	@if uv run python -c "import safety" 2>/dev/null; then \
-		uv run safety check --json > safety-report.json || true; \
-		uv run safety check; \
+	@echo "$(GREEN)Scanning SBOM for known vulnerabilities (osv-scanner)...$(RESET)"
+	@if command -v osv-scanner >/dev/null 2>&1; then \
+		osv-scanner scan source -L sbom.cdx.json --config=osv-scanner.toml; \
 	else \
-		echo "$(YELLOW)⚠ safety not installed. Install with: uv add --dev safety$(RESET)"; \
+		echo "$(YELLOW)⚠ osv-scanner not installed. Install: brew install osv-scanner$(RESET)"; \
+		echo "$(YELLOW)  (CI installs the pinned binary automatically.)$(RESET)"; \
 	fi
 
 validate: lint type-check test ## Full validation (lint + mypy + test) — matches CI
@@ -224,7 +224,6 @@ clean-test: ## Remove test and coverage artifacts
 	rm -rf .coverage
 	rm -f coverage.xml
 	rm -f bandit-report.json
-	rm -f safety-report.json
 
 clean-build: ## Remove build artifacts
 	@echo "$(GREEN)Removing build artifacts...$(RESET)"

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,15 @@ deps-audit: ## Audit dependencies for unused/missing/transitive issues (deptry)
 		echo "$(YELLOW)⚠ deptry not installed. Install with: uv sync --all-extras$(RESET)"; \
 	fi
 
+sbom: ## Generate a CycloneDX SBOM (sbom.cdx.json) from the uv lockfile
+	@echo "$(GREEN)Generating CycloneDX SBOM from uv.lock...$(RESET)"
+	uv export --no-dev --no-emit-project --no-hashes \
+		--format requirements.txt -o sbom-requirements.txt
+	uvx --from cyclonedx-bom cyclonedx-py requirements sbom-requirements.txt \
+		--output-format JSON --spec-version 1.6 --output-file sbom.cdx.json
+	@rm -f sbom-requirements.txt
+	@echo "$(GREEN)✓ sbom.cdx.json generated$(RESET)"
+
 security: ## Run security checks (bandit + safety)
 	@echo "$(GREEN)Checking for security issues in code...$(RESET)"
 	@if uv run python -c "import bandit" 2>/dev/null; then \

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # Documentation: Run 'make help' to see all available targets
 
 .PHONY: help install dev build clean test coverage lint format fix \
-        pre-commit security type-check \
+        pre-commit security type-check deps-audit sbom \
         docker-build-api docker-build-streamlit docker-build-combined \
         docker-build-code-interpreter docker-build-all \
         run-streamlit run-api run-crew update-kb \
@@ -108,6 +108,10 @@ type-check: ## Run type checking with mypy (requires mypy in dev deps)
 		echo "$(YELLOW)⚠ mypy not installed. Install with: uv add --dev mypy$(RESET)"; \
 		exit 1; \
 	fi
+
+deps-audit: ## Audit dependencies for unused/missing/transitive issues (deptry)
+	@echo "$(GREEN)Auditing dependencies with deptry...$(RESET)"
+	uv run deptry .
 
 security: ## Run security checks (bandit + safety)
 	@echo "$(GREEN)Checking for security issues in code...$(RESET)"

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ sbom: ## Generate a CycloneDX SBOM (sbom.cdx.json) from the uv lockfile
 	@echo "$(GREEN)Generating CycloneDX SBOM from uv.lock...$(RESET)"
 	uv export --no-dev --no-emit-project --no-hashes \
 		--format requirements.txt -o sbom-requirements.txt
-	uvx --from cyclonedx-bom cyclonedx-py requirements sbom-requirements.txt \
+	uvx --from "cyclonedx-bom==7.3.0" cyclonedx-py requirements sbom-requirements.txt \
 		--output-format JSON --spec-version 1.6 --output-file sbom.cdx.json
 	@rm -f sbom-requirements.txt
 	@echo "$(GREEN)✓ sbom.cdx.json generated$(RESET)"

--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,11 @@ type-check: ## Run type checking with mypy (requires mypy in dev deps)
 
 deps-audit: ## Audit dependencies for unused/missing/transitive issues (deptry)
 	@echo "$(GREEN)Auditing dependencies with deptry...$(RESET)"
-	uv run deptry .
+	@if uv run python -c "import deptry" 2>/dev/null; then \
+		uv run deptry .; \
+	else \
+		echo "$(YELLOW)⚠ deptry not installed. Install with: uv sync --all-extras$(RESET)"; \
+	fi
 
 security: ## Run security checks (bandit + safety)
 	@echo "$(GREEN)Checking for security issues in code...$(RESET)"

--- a/TODO.md
+++ b/TODO.md
@@ -170,7 +170,7 @@ This document outlines the development roadmap, current tasks, and a history of 
   - **Documentation:** Updated the development guide to reflect the new logging standards.
 
 - **Advanced Testing Libraries:**
-  - **Dependencies:** Integrated `Faker`, `pytest-mock`, and `pendulum` to enhance the testing framework with realistic data generation, mocking, and precise time control.
+  - **Dependencies:** Integrated `Faker` and `pytest-mock` to enhance the testing framework with realistic data generation and mocking.
   - **Standards:** Created sample tests and updated the development guide to establish new testing best practices.
 
 - **Initial Dockerization Setup:**

--- a/docs/how-to/development_setup.md
+++ b/docs/how-to/development_setup.md
@@ -238,24 +238,20 @@ To enhance our testing capabilities, Epic News integrates the following librarie
 
 - **`Faker`**: For generating realistic mock data (e.g., names, addresses, dates). This helps create tests that more closely resemble real-world scenarios.
 - **`pytest-mock`**: A wrapper around the standard `unittest.mock` library, providing a more convenient and pytest-friendly interface for mocking objects and functions.
-- **`pendulum`**: For precise control over date and time in tests. This is crucial for testing time-sensitive logic, allowing you to "freeze" time or travel to specific points in time.
 
 ##### Example Usage
 
 ```python
-import pendulum
 from faker import Faker
 
-def test_faker_and_pendulum():
+def test_with_faker():
     """
-    This test demonstrates the use of Faker and Pendulum.
+    This test demonstrates the use of Faker for realistic mock data.
     """
     fake = Faker()
     name = fake.name()
-    now = pendulum.now()
 
     assert isinstance(name, str)
-    assert isinstance(now, pendulum.DateTime)
 
 def test_mocking_with_pytest_mock(mocker):
     """

--- a/docs/how-to/development_setup.md
+++ b/docs/how-to/development_setup.md
@@ -139,7 +139,7 @@ make coverage         # Run tests with coverage
 
 **Installation & Setup**:
 - `make install` - Install production dependencies
-- `make dev` - Install development dependencies (includes mypy, bandit, safety)
+- `make dev` - Install development dependencies (includes mypy, bandit, deptry)
 - `make build` - Build package distribution
 - `make clean` - Remove all artifacts
 
@@ -155,7 +155,7 @@ make coverage         # Run tests with coverage
 
 **Advanced Quality Checks**:
 - `make type-check` - Run mypy type checking
-- `make security` - Run bandit (code security) + safety (dependency vulnerabilities)
+- `make security` - Run bandit (code security) + osv-scanner (SBOM dependency vulnerabilities)
 
 **Docker Operations**:
 - `make docker-build-api` - Build FastAPI image
@@ -229,7 +229,7 @@ make all              # clean + install + lint + test
 - **Testing**: `make test` (quick) or `make coverage` (with coverage report)
 - **Linting**: `make lint` (check) or `make fix` (auto-fix)
 - **Type Checking**: `make type-check` (requires mypy)
-- **Security**: `make security` (bandit + safety)
+- **Security**: `make security` (bandit + osv-scanner)
 - **Coverage**: Maintain comprehensive test coverage for all utilities
 
 #### Advanced Testing Libraries

--- a/docs/superpowers/plans/2026-06-07-lean-deps-and-sbom.md
+++ b/docs/superpowers/plans/2026-06-07-lean-deps-and-sbom.md
@@ -1,0 +1,704 @@
+# Lean Dependencies + Official, Secured SBOM — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Prune removable dependencies, tame the Dependabot PR flood, and produce an official CycloneDX SBOM that is vuln-scanned (replacing deprecated `safety`) and published as a release artifact.
+
+**Architecture:** Pure tooling/config change — no application logic changes except removing one dead optional-import branch and declaring four currently-undeclared direct imports. SBOM is generated from `uv.lock` via `uv export` → `cyclonedx-py requirements` (run through `uvx`, no added lockfile weight). `osv-scanner` scans the generated SBOM with a documented allowlist. A new `security.yml` workflow runs the scan on PR/push/weekly-schedule and attaches the SBOM to GitHub Releases on tags. `deptry` is added as an ongoing dependency-hygiene guardrail.
+
+**Tech Stack:** `uv`, `cyclonedx-bom` 7.3.0 (via `uvx`), `osv-scanner` v2.3.8, `deptry`, GitHub Actions (`actions/checkout@v6`, `astral-sh/setup-uv@v8.1.0`, `actions/upload-artifact@v4`), `gh` CLI.
+
+**Spec:** `docs/superpowers/specs/2026-06-07-lean-deps-and-sbom-design.md`
+
+**Validated facts (do not re-derive):**
+- `cyclonedx-bom` 7.3.0 has **no** `uv` subcommand. Use `requirements` subcommand. Flags: `--output-format JSON|XML`, `--spec-version`/`--sv`, `--output-file`/`-o`. Proven to emit CycloneDX 1.6 with 236 runtime components.
+- `osv-scanner` scans an SBOM via `osv-scanner scan source -L <file>` (SBOM auto-detected by the `.cdx.json` suffix). Config file is `osv-scanner.toml` (no leading dot), `[[IgnoredVulns]]` entries take `id`, `reason`, optional `ignoreUntil = YYYY-MM-DD`. Exits non-zero on un-ignored findings.
+- osv-scanner v2.3.8 linux asset: `https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64`.
+- Working branch is `chore/lean-deps-sbom` (already created).
+
+---
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `pyproject.toml` | Dependency declarations + `[tool.deptry]` config | Modify |
+| `src/epic_news/app.py` | Streamlit app; `html_to_markdown` helper | Modify (drop dead branch) |
+| `tests/test_advanced_libraries.py` | Library smoke tests | Modify (drop pendulum test) |
+| `Makefile` | Dev/CI command targets | Modify (`sbom`, `deps-audit`, rewrite `security`, `.PHONY`, clean) |
+| `osv-scanner.toml` | Vuln allowlist (documented ignores) | Create |
+| `.github/dependabot.yml` | Update grouping/caps | Replace |
+| `.github/workflows/security.yml` | SBOM + scan + release-attach CI | Create |
+| `.gitignore` | Ignore generated SBOM artifacts | Modify |
+
+---
+
+## Task 1: Prune safe-removal dependencies
+
+Removes `chromadb` (redundant runtime pin — `crewai` hard-depends `chromadb~=1.1.0`), `langsmith` + `pendulum` (test, unused/meta-test only), and `vulture` (dev tool never invoked).
+
+**Files:**
+- Modify: `pyproject.toml` (dependencies, optional-dependencies.test, dependency-groups.dev)
+- Modify: `tests/test_advanced_libraries.py`
+
+- [ ] **Step 1: Remove `chromadb` from runtime dependencies**
+
+In `pyproject.toml`, delete this line from `[project] dependencies`:
+
+```toml
+    "chromadb>=0.5.23",
+```
+
+- [ ] **Step 2: Remove `langsmith` and `pendulum` from the test extra**
+
+In `pyproject.toml` `[project.optional-dependencies] test`, delete these two lines:
+
+```toml
+    "pendulum>=3.1.0",
+    "langsmith",
+```
+
+- [ ] **Step 3: Remove `vulture` from the dev group**
+
+In `pyproject.toml` `[dependency-groups] dev`, delete this line:
+
+```toml
+    "vulture>=2.14",
+```
+
+- [ ] **Step 4: Drop the pendulum meta-test**
+
+Replace the entire contents of `tests/test_advanced_libraries.py` with (removes `pendulum` + `faker` imports and the `test_faker_and_pendulum` function — `faker` remains used in other test files; keeps the `pytest-mock` test):
+
+```python
+def test_mocking_with_pytest_mock(mocker):
+    """
+    This test demonstrates the use of pytest-mock.
+    """
+    # Create a mock object
+    mock_object = mocker.Mock()
+
+    # Configure the mock to return a specific value when a method is called
+    mock_object.get_name.return_value = "Test Name"
+
+    # Call the method on the mock object
+    result = mock_object.get_name()
+
+    # Assert that the method was called and returned the expected value
+    mock_object.get_name.assert_called_once()
+    assert result == "Test Name"
+```
+
+- [ ] **Step 5: Re-lock and sync**
+
+Run: `uv lock && uv sync --all-extras`
+Expected: resolves successfully; `uv.lock` updated; no errors. `chromadb` remains in the lock (now pulled transitively by `crewai`); `langsmith`, `pendulum`, `vulture` removed from the resolved dev/test set.
+
+- [ ] **Step 6: Verify chromadb still present transitively (regression guard)**
+
+Run: `uv run python -c "import chromadb; print('chromadb', chromadb.__version__)"`
+Expected: prints a `chromadb 1.x` version (proves dropping the direct pin did not remove it).
+
+- [ ] **Step 7: Run the test suite**
+
+Run: `uv run pytest -q`
+Expected: PASS (no collection error for the removed `test_faker_and_pendulum`; `faker`-using tests elsewhere still pass).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add pyproject.toml uv.lock tests/test_advanced_libraries.py
+git commit -m "chore(deps): prune chromadb pin, langsmith, pendulum, vulture
+
+chromadb is a hard transitive dep of crewai (~=1.1.0); our >=0.5.23 pin
+was redundant and misleading. langsmith unused; pendulum only in a
+library meta-test; vulture never invoked in Makefile/pre-commit/CI.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Fix undeclared-but-imported dependencies
+
+Removes the dead `markdownify` optional branch (a BeautifulSoup fallback already exists) and declares `tabulate`, `urllib3`, and `python-dateutil` — currently imported directly but only present transitively (latent breakage). Declaring `urllib3`/`python-dateutil` adds **no** new resolved packages.
+
+**Files:**
+- Modify: `src/epic_news/app.py:43-63`
+- Modify: `pyproject.toml`
+- Test: `tests/test_html_to_markdown.py` (Create)
+
+- [ ] **Step 1: Write a failing test for `html_to_markdown`**
+
+Create `tests/test_html_to_markdown.py`:
+
+```python
+from epic_news.app import html_to_markdown
+
+
+def test_html_to_markdown_extracts_text():
+    html = "<h1>Title</h1><p>Hello <b>world</b></p>"
+    result = html_to_markdown(html)
+    assert "Title" in result
+    assert "Hello" in result
+    assert "world" in result
+    assert "<" not in result  # tags stripped
+
+
+def test_html_to_markdown_handles_garbage_gracefully():
+    # Non-HTML input must not raise.
+    assert isinstance(html_to_markdown(""), str)
+```
+
+- [ ] **Step 2: Run the test to verify current behavior**
+
+Run: `uv run pytest tests/test_html_to_markdown.py -v`
+Expected: PASS today (the function already works via the markdownify branch or bs4 fallback). This test pins the behavior we must preserve after removing the branch.
+
+- [ ] **Step 3: Remove the `markdownify` branch in `app.py`**
+
+In `src/epic_news/app.py`, replace the `html_to_markdown` function (currently lines ~43-63) with:
+
+```python
+def html_to_markdown(html: str) -> str:
+    """Best-effort HTML→Markdown conversion for displaying/downloading.
+
+    Uses BeautifulSoup text extraction; returns original HTML on failure.
+    """
+    try:
+        from bs4 import BeautifulSoup
+
+        soup = BeautifulSoup(html, "html.parser")
+        # Keep basic structure using newlines
+        text = soup.get_text("\n")
+        return text.strip()
+    except Exception:
+        return html
+```
+
+- [ ] **Step 4: Run the test to verify behavior preserved**
+
+Run: `uv run pytest tests/test_html_to_markdown.py -v`
+Expected: PASS (text extraction still works via bs4).
+
+- [ ] **Step 5: Declare `tabulate` in the dev group**
+
+In `pyproject.toml` `[dependency-groups] dev`, add (alphabetical-ish, after `safety`/before `yamllint` is fine):
+
+```toml
+    "tabulate>=0.9.0",
+```
+
+- [ ] **Step 6: Declare `urllib3` and `python-dateutil` in runtime dependencies**
+
+In `pyproject.toml` `[project] dependencies`, under the `# --- HTTP / Web ---` section add:
+
+```toml
+    "urllib3>=2.0.0",
+```
+
+and under `# --- Data sources / scraping ---` add:
+
+```toml
+    "python-dateutil>=2.9.0",
+```
+
+- [ ] **Step 7: Re-lock and sync**
+
+Run: `uv lock && uv sync --all-extras`
+Expected: resolves with no version changes to the transitive tree (these were already present); `urllib3` / `python-dateutil` / `tabulate` now appear as direct.
+
+- [ ] **Step 8: Run lint + the focused test**
+
+Run: `uv run ruff check src/epic_news/app.py && uv run pytest tests/test_html_to_markdown.py -q`
+Expected: lint clean, tests PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add pyproject.toml uv.lock src/epic_news/app.py tests/test_html_to_markdown.py
+git commit -m "chore(deps): declare urllib3/dateutil/tabulate, drop dead markdownify branch
+
+urllib3 (tools/*_base.py) and python-dateutil (unified_rss_tool.py) were
+imported directly but only present transitively. tabulate is used by
+scripts/optimize_crews.py. markdownify branch removed (bs4 fallback covers it).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Add `deptry` dependency-hygiene guardrail
+
+**Files:**
+- Modify: `pyproject.toml` (dev group + `[tool.deptry]`)
+- Modify: `Makefile` (`deps-audit` target + `.PHONY`)
+
+- [ ] **Step 1: Add `deptry` to the dev group**
+
+In `pyproject.toml` `[dependency-groups] dev`, add:
+
+```toml
+    "deptry>=0.20.0",
+```
+
+- [ ] **Step 2: Add the `[tool.deptry]` config**
+
+Append to `pyproject.toml` (after the `[tool.bandit]` block). This ignore-set was validated to produce a **clean exit** against the post-prune codebase:
+
+```toml
+[tool.deptry]
+known_first_party = ["epic_news"]
+# Treat the `test` optional-dependency group as dev so test-only libs are not
+# flagged as unused in the runtime source.
+pep621_dev_dependency_groups = ["test"]
+
+[tool.deptry.per_rule_ignores]
+# DEP002: declared but not imported in our source — intentional.
+DEP002 = [
+    "litellm",          # LLM backend used by crewai at runtime; CVE-floor pin, not imported
+    "uvicorn",          # ASGI server invoked via CLI (Dockerfile.api, Makefile)
+    "lxml",             # required transitively by newspaper3k at runtime
+    "lxml-html-clean",  # required by newspaper3k (lxml.html.clean split-out)
+    "wikipedia-mcp-server",  # launched via MCP config command string, not imported
+    # pytest plugins / CLI tools (used via fixtures or config, never imported)
+    "pytest-cov", "pytest-asyncio", "pytest-env", "pytest-mock",
+    "pytest-regressions", "pytest-datadir", "coverage",
+]
+# DEP003: editable self-install shows up as transitive — it is first-party.
+DEP003 = ["epic_news"]
+```
+
+- [ ] **Step 3: Add the `deps-audit` Makefile target**
+
+In `Makefile`, add this target (place it just before the `security:` target around line 112):
+
+```makefile
+deps-audit: ## Audit dependencies for unused/missing/transitive issues (deptry)
+	@echo "$(GREEN)Auditing dependencies with deptry...$(RESET)"
+	uv run deptry .
+```
+
+- [ ] **Step 4: Register `deps-audit` in `.PHONY`**
+
+In `Makefile`, change the `.PHONY` line (currently line 6):
+
+```makefile
+        pre-commit security type-check \
+```
+
+to:
+
+```makefile
+        pre-commit security type-check deps-audit sbom \
+```
+
+(`sbom` is added now to avoid a second edit in Task 4.)
+
+- [ ] **Step 5: Sync and run the audit**
+
+Run: `uv sync --all-extras && make deps-audit`
+Expected: deptry runs and exits **0** ("Success! No dependency issues found"). If any DEP00x line appears, it is a real new issue — fix the import or add a justified ignore; do not suppress blindly.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add pyproject.toml uv.lock Makefile
+git commit -m "chore(deps): add deptry guardrail + make deps-audit target
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: SBOM generation (`make sbom`)
+
+**Files:**
+- Modify: `Makefile` (`sbom` target)
+- Modify: `.gitignore`
+
+- [ ] **Step 1: Add the `sbom` Makefile target**
+
+In `Makefile`, add this target immediately after the `deps-audit` target from Task 3 (the validated, working command sequence):
+
+```makefile
+sbom: ## Generate a CycloneDX SBOM (sbom.cdx.json) from the uv lockfile
+	@echo "$(GREEN)Generating CycloneDX SBOM from uv.lock...$(RESET)"
+	uv export --no-dev --no-emit-project --no-hashes \
+		--format requirements.txt -o sbom-requirements.txt
+	uvx --from cyclonedx-bom cyclonedx-py requirements sbom-requirements.txt \
+		--output-format JSON --spec-version 1.6 --output-file sbom.cdx.json
+	@rm -f sbom-requirements.txt
+	@echo "$(GREEN)✓ sbom.cdx.json generated$(RESET)"
+```
+
+- [ ] **Step 2: Ignore generated SBOM artifacts**
+
+Append to `.gitignore`:
+
+```gitignore
+# Generated SBOM artifacts (produced fresh in CI / on demand)
+sbom.cdx.json
+sbom-requirements.txt
+```
+
+- [ ] **Step 3: Generate and validate the SBOM**
+
+Run: `make sbom`
+Expected: prints "✓ sbom.cdx.json generated"; `sbom.cdx.json` exists.
+
+- [ ] **Step 4: Verify it is valid CycloneDX**
+
+Run:
+```bash
+uv run python -c "import json; d=json.load(open('sbom.cdx.json')); assert d['bomFormat']=='CycloneDX'; assert d['specVersion']=='1.6'; print('components:', len(d['components']))"
+```
+Expected: prints `components: <N>` with N > 200; no assertion error.
+
+- [ ] **Step 5: Confirm the artifact is git-ignored**
+
+Run: `git status --porcelain sbom.cdx.json`
+Expected: empty output (file ignored, not tracked).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Makefile .gitignore
+git commit -m "feat(security): add make sbom (CycloneDX from uv.lock)
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Replace `safety` with `osv-scanner` vuln scanning
+
+**Files:**
+- Modify: `pyproject.toml` (remove `safety`)
+- Create: `osv-scanner.toml`
+- Modify: `Makefile` (rewrite `security`, update `clean-test`)
+
+- [ ] **Step 1: Remove `safety` from the dev group**
+
+In `pyproject.toml` `[dependency-groups] dev`, delete this line:
+
+```toml
+    "safety>=3.8.1",
+```
+
+- [ ] **Step 2: Create the allowlist `osv-scanner.toml`**
+
+Create `osv-scanner.toml` at the repo root:
+
+```toml
+# OSV-Scanner vulnerability allowlist.
+# Each entry MUST carry a reason and SHOULD carry an ignoreUntil review date.
+# Format: https://google.github.io/osv-scanner/configuration/
+#
+# Seed entry (commented) for the known unfixable upstream chain documented in
+# pyproject.toml (crewai 1.14.x <-> pydantic <-> litellm). Uncomment and set the
+# real OSV id + expiry if/when osv-scanner reports it and no fix is available.
+#
+# [[IgnoredVulns]]
+# id = "GHSA-xxxx-xxxx-xxxx"
+# ignoreUntil = 2026-09-01
+# reason = "Transitive via crewai 1.14.x pydantic/litellm pin; no compatible fix upstream yet."
+```
+
+- [ ] **Step 3: Rewrite the `security` Makefile target**
+
+In `Makefile`, replace the entire `security:` target (currently lines ~112-127) with:
+
+```makefile
+security: sbom ## Run security checks (bandit + osv-scanner against the SBOM)
+	@echo "$(GREEN)Checking for security issues in code...$(RESET)"
+	@if uv run python -c "import bandit" 2>/dev/null; then \
+		uv run bandit -r $(SRC_DIR) -f json -o bandit-report.json || true; \
+		uv run bandit -r $(SRC_DIR); \
+	else \
+		echo "$(YELLOW)⚠ bandit not installed. Install with: uv add --dev bandit$(RESET)"; \
+	fi
+	@echo ""
+	@echo "$(GREEN)Scanning SBOM for known vulnerabilities (osv-scanner)...$(RESET)"
+	@if command -v osv-scanner >/dev/null 2>&1; then \
+		osv-scanner scan source -L sbom.cdx.json --config=osv-scanner.toml; \
+	else \
+		echo "$(YELLOW)⚠ osv-scanner not installed. Install: brew install osv-scanner$(RESET)"; \
+		echo "$(YELLOW)  (CI installs the pinned binary automatically.)$(RESET)"; \
+	fi
+```
+
+- [ ] **Step 4: Drop the `safety-report.json` cleanup line**
+
+In `Makefile` `clean-test` target (around line 209-210), delete this line:
+
+```makefile
+	rm -f safety-report.json
+```
+
+- [ ] **Step 5: Sync (removes safety)**
+
+Run: `uv lock && uv sync --all-extras`
+Expected: `safety` no longer in the resolved dev set.
+
+- [ ] **Step 6: Run security locally**
+
+Run: `make security`
+Expected: SBOM regenerates; `bandit` runs and reports; the osv-scanner step either runs clean (exit 0) if installed, or prints the install hint. If `osv-scanner` IS installed locally and reports an un-ignored vuln, that is a real finding — record it in `osv-scanner.toml` with a reason or fix the dependency.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add pyproject.toml uv.lock Makefile osv-scanner.toml
+git commit -m "feat(security): replace deprecated safety with osv-scanner SBOM scan
+
+bandit + osv-scanner against the CycloneDX SBOM, gated by a documented
+osv-scanner.toml allowlist. Removes safety (now login-gated/deprecated).
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Tame the Dependabot PR flood
+
+**Files:**
+- Modify: `.github/dependabot.yml`
+
+- [ ] **Step 1: Replace `.github/dependabot.yml`**
+
+Replace the entire file with (groups all minor+patch Python bumps into one weekly PR, caps open PRs, and adds a grouped github-actions ecosystem; major bumps stay individual so they get attention):
+
+```yaml
+---
+# Dependabot: grouped, capped updates to minimise upgrade-chore noise.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions-all:
+        patterns:
+          - "*"
+```
+
+- [ ] **Step 2: Validate YAML**
+
+Run: `uv run yamllint .github/dependabot.yml`
+Expected: no errors (the repo's yamllint config disables line-length; `---` start and final newline are present).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/dependabot.yml
+git commit -m "ci(deps): group + cap dependabot updates; add github-actions ecosystem
+
+Collapses the weekly per-package chore(deps) flood into grouped
+minor/patch PRs (majors stay individual). Adds grouped action updates.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: CI security workflow (`security.yml`)
+
+Runs SBOM generation, `deptry`, and `osv-scanner` on PR/push/weekly-schedule; uploads the SBOM as an artifact always; attaches it to the GitHub Release on tag pushes.
+
+**Files:**
+- Create: `.github/workflows/security.yml`
+
+- [ ] **Step 1: Create `.github/workflows/security.yml`**
+
+```yaml
+---
+name: Security & SBOM
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+    tags: ["v*"]
+  schedule:
+    - cron: "0 6 * * 1"  # Mondays 06:00 UTC — catch newly-disclosed CVEs
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  sbom-and-scan:
+    name: SBOM + vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Sync dependencies (locked)
+        run: uv sync --all-extras --locked
+
+      - name: Generate CycloneDX SBOM
+        run: make sbom
+
+      - name: Dependency hygiene audit (deptry)
+        run: make deps-audit
+
+      - name: Install osv-scanner (pinned)
+        run: |
+          curl -sSL \
+            https://github.com/google/osv-scanner/releases/download/v2.3.8/osv-scanner_linux_amd64 \
+            -o osv-scanner
+          chmod +x osv-scanner
+          ./osv-scanner --version
+
+      - name: Vulnerability scan (blocking, honors allowlist)
+        run: ./osv-scanner scan source -L sbom.cdx.json --config=osv-scanner.toml
+
+      - name: Upload SBOM artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: sbom-cyclonedx
+          path: sbom.cdx.json
+          if-no-files-found: error
+
+  publish-sbom:
+    name: Attach SBOM to GitHub Release
+    needs: sbom-and-scan
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Generate CycloneDX SBOM
+        run: make sbom
+
+      - name: Upload SBOM to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release view "${GITHUB_REF_NAME}" >/dev/null 2>&1 \
+            || gh release create "${GITHUB_REF_NAME}" --generate-notes
+          gh release upload "${GITHUB_REF_NAME}" sbom.cdx.json --clobber
+```
+
+- [ ] **Step 2: Validate workflow YAML**
+
+Run: `uv run yamllint .github/workflows/security.yml`
+Expected: no errors.
+
+- [ ] **Step 3: (Optional) Static-check with actionlint if available**
+
+Run: `command -v actionlint >/dev/null && actionlint .github/workflows/security.yml || echo "actionlint not installed — skipping"`
+Expected: no errors, or the skip message.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/security.yml
+git commit -m "ci(security): add SBOM + osv-scanner workflow, attach SBOM to releases
+
+PR/push/weekly scan of the CycloneDX SBOM (blocking, allowlist-gated),
+deptry hygiene audit, SBOM uploaded as artifact always and attached to
+GitHub Releases on v* tags.
+
+Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Full validation + push
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Full local validation**
+
+Run: `make validate`
+Expected: lint + mypy + tests all pass (matches CI's gate).
+
+- [ ] **Step 2: Security + SBOM end-to-end**
+
+Run: `make security`
+Expected: SBOM regenerates, bandit clean, osv-scanner runs clean (or prints install hint locally).
+
+- [ ] **Step 3: Dependency audit clean**
+
+Run: `make deps-audit`
+Expected: deptry exits 0.
+
+- [ ] **Step 4: Confirm no stray tracked artifacts**
+
+Run: `git status --porcelain`
+Expected: clean (no `sbom.cdx.json` / `sbom-requirements.txt` / `bandit-report.json` tracked).
+
+- [ ] **Step 5: Push the branch and open a PR**
+
+```bash
+git push -u origin chore/lean-deps-sbom
+gh pr create --title "Lean dependencies + official secured SBOM" \
+  --body "Implements docs/superpowers/specs/2026-06-07-lean-deps-and-sbom-design.md.
+
+- Prune: chromadb pin, langsmith, pendulum, vulture
+- Declare undeclared imports: urllib3, python-dateutil, tabulate; drop dead markdownify branch
+- deptry guardrail (make deps-audit)
+- CycloneDX SBOM (make sbom) from uv.lock
+- Replace deprecated safety with osv-scanner (allowlist-gated, blocking)
+- Dependabot grouping + caps + github-actions ecosystem
+- security.yml: scan on PR/push/weekly, attach SBOM to releases"
+```
+
+- [ ] **Step 6: Verify CI is green**
+
+After the PR opens, confirm both the existing `CI` workflow and the new `Security & SBOM` workflow pass. Per project rule, no red checks may merge — fix any failure in this PR. Also check CodeRabbitAI comments before merge.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Lean/prune (spec §1a–1e) → Tasks 1, 2 (+ deptry §2 → Task 3). Follow-up `newspaper3k`→`trafilatura` is explicitly out of scope per spec; not planned here. ✓
+- Tame dependabot noise (spec §3) → Task 6. ✓
+- SBOM generation, CycloneDX (spec §4) → Task 4. ✓
+- Vuln scan, drop safety, allowlist (spec §5) → Task 5. ✓
+- CI workflow (spec §6) → Task 7. ✓
+- Official publication / release artifact (spec §7) → Task 7 `publish-sbom` job. ✓
+- No signing/SPDX/image-SBOM (spec non-goals) → correctly absent. ✓
+
+**Placeholder scan:** No TBD/TODO; every code/config block is complete; all commands have expected output. The seed `[[IgnoredVulns]]` in `osv-scanner.toml` is intentionally commented (no active CVE to ignore yet) — documented as such, not a placeholder.
+
+**Type/name consistency:** `make sbom` produces `sbom.cdx.json`; Tasks 5 & 7 scan exactly that filename via `-L sbom.cdx.json`. `osv-scanner.toml` (no dot) is consistent across the config file, `make security`, and `security.yml`. `deps-audit`/`sbom` both registered in `.PHONY` (Task 3 Step 4). osv-scanner version `v2.3.8` consistent between Makefile hint and CI download.

--- a/docs/superpowers/specs/2026-06-07-lean-deps-and-sbom-design.md
+++ b/docs/superpowers/specs/2026-06-07-lean-deps-and-sbom-design.md
@@ -62,14 +62,53 @@ uv.lock
 
 ### 1. Dependency pruning (one-time, evidence-driven)
 
-Based on an import-usage audit of `src/` + `tests/`:
+Full audit of **all** direct deps (40 runtime + 12 test + 8 dev) via `deptry` (in-env) plus an
+import-usage sweep with corrected package→module mapping across `src/`, `tests/`, `scripts/`,
+and non-import usages (CLI tools, pytest plugins/fixtures, MCP/config strings).
+
+**1a. Safe removals (this pass):**
+
+| Dep | Group | Evidence | Action |
+|---|---|---|---|
+| `langsmith` | test | 0 imports anywhere | **Remove** |
+| `chromadb` | runtime | 0 imports; `crewai` hard-depends `chromadb~=1.1.0`. Our `>=0.5.23` pin is redundant *and* lower than crewai's actual floor (misleading). | **Remove direct pin** (transitive-guaranteed) |
+| `vulture` | dev | declared but **never invoked** (no Makefile/pre-commit/CI reference) | **Remove** (or wire up — chosen: remove) |
+
+**1b. Imported-but-undeclared (latent breakage — only works via transitive luck):**
+
+| Dep | Where | Action |
+|---|---|---|
+| `markdownify` | `src/epic_news/app.py:51` — optional import with an existing BeautifulSoup fallback | **Drop the optional branch** (fallback already covers it) → no new dep |
+| `tabulate` | `scripts/optimize_crews.py:18` | **Declare in `dev` group** (script-only utility) |
+
+**1c. Biggest lean win (follow-up — touches scraping behavior, NOT this pass):**
+
+`newspaper3k` is unmaintained (last release 2018) and is the **only** importer of `lxml` /
+`lxml-html-clean` in the tree. Replacing it with `trafilatura` (maintained, lighter) cascades:
+
+| Dep | Evidence | Action (follow-up) |
+|---|---|---|
+| `newspaper3k` | 1 file; unmaintained 2018 | Replace with `trafilatura` |
+| `lxml` (direct pin) | 0 direct imports; bs4 uses stdlib `html.parser` everywhere; only transitive via `newspaper3k` | Drop direct pin once `newspaper3k` is gone |
+| `lxml-html-clean` | 0 imports; only required by `newspaper3k` (`lxml.html.clean` split-out) | Drop once `newspaper3k` is gone |
+
+→ Replacing **1 unmaintained dep removes up to 3 direct deps.** Deferred because it changes
+article-extraction behavior and deserves its own change + verification.
+
+**1d. Low-priority:**
 
 | Dep | Evidence | Action |
 |---|---|---|
-| `langsmith` (test extra) | 0 imports | **Remove** |
-| `chromadb` (runtime, heavy) | 0 direct imports; provided transitively by `crewai` | **Drop direct pin** after verifying `crewai`'s resolved range still satisfies runtime |
-| `lxml-html-clean` | 0 direct imports | **Verify** runtime need (`lxml.html.clean` was split out; may be required by `newspaper3k`/scraping). Keep only if needed; document why. |
-| `newspaper3k` | 1 file; unmaintained since 2018, pins old `lxml` | **Flag** as chore-magnet → follow-up (replace with `trafilatura` or isolate). Not changed in this pass. |
+| `pendulum` | test | Used only in `tests/test_advanced_libraries.py`, which tests faker+pendulum *themselves*, not project code | Remove dep + that meta-test (optional) |
+
+**1e. Keep (verified, with rationale):**
+
+- `litellm` — intentional CVE-floor pin (`>=1.87.0`); only an *optional* extra in `crewai`
+  (`litellm<1.84; extra=='litellm'`), so it must stay declared directly. Documented constraint.
+- `uvicorn` — runtime ASGI server invoked via CLI (`Dockerfile.api`, `Makefile`), not imported.
+- `composio` — imported directly (`from composio import Composio`); also transitive via
+  `composio-crewai`. Kept for explicit-import hygiene.
+- All remaining runtime/test/dev deps are actively imported or invoked.
 
 Each removal verified by: `uv sync`, `make lint`, `make test`, `make security`, `make sbom` all green.
 
@@ -132,7 +171,9 @@ New `.github/workflows/security.yml`:
 - Honors the project's "no red CI" rule and the existing unfixable-upstream constraint by
   making suppression explicit and auditable rather than silently non-blocking.
 - SBOM artifact is uploaded even when the scan step fails, so findings are inspectable.
-- `deptry` false positives handled via its ignore config, not by disabling the check.
+- `deptry` false positives handled via its ignore config (e.g. DEP003 for the editable
+  `epic_news` self-package; DEP002 for CLI-only dev tools and `litellm`/`uvicorn` intentional
+  non-imported runtime deps), not by disabling the check.
 
 ## Verification
 
@@ -145,18 +186,24 @@ New `.github/workflows/security.yml`:
 
 ## Affected Files (anticipated)
 
-- `pyproject.toml` — remove `langsmith`, `chromadb` (verify), `safety`; add `deptry`,
-  `cyclonedx-py`; add `[tool.deptry]` config.
+- `pyproject.toml` — remove `langsmith`, `chromadb`, `safety`, `vulture` (and optionally
+  `pendulum`); add `deptry`, `cyclonedx-py`, `tabulate` (dev); add `[tool.deptry]` config.
+- `src/epic_news/app.py` — drop the optional `markdownify` import branch (keep bs4 fallback).
+- `tests/test_advanced_libraries.py` — remove if `pendulum` is dropped (it tests libs, not us).
 - `.github/dependabot.yml` — groups + caps + github-actions ecosystem.
 - `.github/workflows/security.yml` — **new**.
 - `Makefile` — `sbom`, `deps-audit` targets; rewrite `security`; drop `safety` branches/cleanup.
 - `.osv-scanner.toml` — **new** (allowlist).
 - `.gitignore` — ignore `sbom.cdx.json` (build artifact).
 - `uv.lock` — regenerated.
+- **Follow-up change (separate):** `newspaper3k` → `trafilatura`, then drop `lxml` +
+  `lxml-html-clean`.
 
 ## Open Items for Implementation Plan
 
-- Confirm `crewai` resolved range keeps `chromadb` available before dropping the pin.
-- Confirm `lxml-html-clean` runtime requirement (keep vs remove).
+- Confirm nothing breaks after dropping the `chromadb` direct pin (transitive via `crewai`).
+- Confirm `markdownify`-branch removal leaves `app.py` markdown handling correct (fallback path).
+- Decide whether to drop `pendulum` + its meta-test in this pass or defer.
 - Decide `cyclonedx-py` install (`dev` dep vs `uvx`) and pin policy.
 - Decide release-attach lives in `security.yml` vs a new `release.yml`.
+- Follow-up: scope the `newspaper3k`→`trafilatura` migration (extraction-quality parity check).

--- a/docs/superpowers/specs/2026-06-07-lean-deps-and-sbom-design.md
+++ b/docs/superpowers/specs/2026-06-07-lean-deps-and-sbom-design.md
@@ -1,0 +1,162 @@
+# Design: Lean Dependencies + Official, Secured SBOM
+
+- **Date:** 2026-06-07
+- **Status:** Approved (design); pending implementation plan
+- **Author:** Frederic Jacquet (with Claude Code)
+
+## Problem
+
+Two related maintenance pains:
+
+1. **Dependency-upgrade chore.** ~40 direct runtime deps + 13 test + 8 dev resolve to
+   ~1000 locked packages. Dependabot runs `uv` weekly, **ungrouped with no PR cap**, so it
+   produces a flood of individual `chore(deps)` PRs (recent history: #110–#113 all dep bumps).
+2. **No SBOM, decaying security tooling.** There is no Software Bill of Materials anywhere.
+   Security is `bandit` + `safety`, and `safety check` is deprecated (now requires an
+   account/login), making it its own upgrade chore.
+
+## Goals
+
+- **Lean deps:** prune what is removable *and* tame the dependabot PR noise.
+- **Official SBOM:** generate a standard, machine-readable SBOM on every build.
+- **Secured SBOM:** vuln-scan it with a free, no-login tool; replace `safety`.
+- **Publish:** distribute the SBOM as an official release artifact.
+
+## Non-Goals (YAGNI)
+
+- SBOM signing / attestation / SLSA provenance.
+- SPDX format (CycloneDX only).
+- Per-image OS-package SBOMs for the Docker images (possible later add-on).
+- Replacing `newspaper3k` in this pass (flagged as a follow-up; it changes scraping behavior).
+
+## Decisions (from brainstorming)
+
+| Question | Decision |
+|---|---|
+| Lean scope | **Prune AND tame noise** |
+| SBOM layers | **Generate + vuln-scan (drop `safety`) + publish as release artifact** (no signing) |
+| SBOM format | **CycloneDX** |
+| Scan gating | **Blocking + documented allowlist** (respects "no red CI" + unfixable-upstream constraint) |
+| Tooling | **uv-native Python stack** (Approach A): `cyclonedx-py` + `osv-scanner` + `deptry` |
+
+### Tooling alternatives considered
+
+- **A. `cyclonedx-py` + `osv-scanner` + `deptry` (chosen).** Lockfile-native, lean, single
+  source of truth: generate the SBOM, scan that same SBOM, publish it. Python-only coverage.
+- **B. `syft` + `grype` (Anchore).** Can SBOM Docker images incl. OS packages; one vendor.
+  Rejected for now: Go binaries, heavier, noisier (whole-image), and image SBOMs weren't requested.
+- **C. GitHub-native (dependency graph + Dependabot alerts).** Zero tooling but produces no
+  portable CycloneDX file — fails the "create it officially" goal.
+
+## Architecture / Data Flow
+
+```
+uv.lock
+  └─(cyclonedx-py uv)─▶ sbom.cdx.json  (CycloneDX JSON)
+                          ├─(osv-scanner --sbom, honors .osv-scanner.toml)─▶ CI gate (blocking)
+                          ├─(actions/upload-artifact)──────────────────────▶ workflow artifact (always)
+                          └─(on tag v*)────────────────────────────────────▶ GitHub Release asset
+```
+
+## Components
+
+### 1. Dependency pruning (one-time, evidence-driven)
+
+Based on an import-usage audit of `src/` + `tests/`:
+
+| Dep | Evidence | Action |
+|---|---|---|
+| `langsmith` (test extra) | 0 imports | **Remove** |
+| `chromadb` (runtime, heavy) | 0 direct imports; provided transitively by `crewai` | **Drop direct pin** after verifying `crewai`'s resolved range still satisfies runtime |
+| `lxml-html-clean` | 0 direct imports | **Verify** runtime need (`lxml.html.clean` was split out; may be required by `newspaper3k`/scraping). Keep only if needed; document why. |
+| `newspaper3k` | 1 file; unmaintained since 2018, pins old `lxml` | **Flag** as chore-magnet → follow-up (replace with `trafilatura` or isolate). Not changed in this pass. |
+
+Each removal verified by: `uv sync`, `make lint`, `make test`, `make security`, `make sbom` all green.
+
+### 2. Dependency guardrail (ongoing)
+
+- Add **`deptry`** to the `dev` dependency group.
+- Add a `make deps-audit` target running `uv run deptry src`.
+- Configure `deptry` (in `pyproject.toml`) with a small ignore-list for intentional
+  transitive/optional deps (e.g. anything kept by design).
+- Wire `deptry` into CI (the new `security.yml`, non-flaky step).
+
+### 3. Tame dependabot noise
+
+Rewrite `.github/dependabot.yml`:
+
+- `package-ecosystem: uv`, `directory: /`, `schedule: weekly`.
+- **Groups:** `dev-dependencies` (all dev/test, minor+patch), `runtime` (minor+patch); major
+  bumps remain individual PRs.
+- `open-pull-requests-limit: 5`.
+- Add a second `package-ecosystem: github-actions` block (workflows pin action versions),
+  grouped, weekly. Net effect: ~10 PRs/week → ~2–3.
+
+### 4. SBOM generation
+
+- Add `cyclonedx-py` to the `dev` group (or run via `uvx` — decided at plan time).
+- `make sbom` → `cyclonedx-py uv --output-format JSON -o sbom.cdx.json`.
+- `sbom.cdx.json` is a build artifact: git-ignored locally, produced fresh in CI.
+
+> **API note:** exact `cyclonedx-py` and `osv-scanner` CLI flags are validated against current
+> docs (via context7 / official docs) during implementation before code is written.
+
+### 5. Vuln scanning (replaces `safety`)
+
+- Add `.osv-scanner.toml` with documented `[[IgnoredVulns]]` entries (id + `reason` + review
+  date), seeded with the known unfixable `litellm`/`pydantic`/`crewai` chain if it surfaces a CVE.
+- Rewrite `make security`: `bandit -r src` + `osv-scanner --sbom sbom.cdx.json`.
+- **Remove `safety`:** dev dependency, Makefile branches, and `safety-report.json` cleanup.
+
+### 6. CI workflow
+
+New `.github/workflows/security.yml`:
+
+- **Triggers:** `pull_request` (→ main), `push` (→ main), `schedule` (weekly — catches
+  newly-disclosed CVEs with no code change), `workflow_dispatch`.
+- **Steps:** checkout → setup uv → `make sbom` → `make deps-audit` → `osv-scanner` (blocking,
+  honors allowlist) → `actions/upload-artifact` `sbom.cdx.json` (always, even on failure).
+- **Permissions:** `contents: read` (least privilege).
+
+### 7. Official publication
+
+- On git tag `v*`: a job (in `security.yml` or a dedicated `release.yml`) attaches
+  `sbom.cdx.json` to the GitHub Release for that tag.
+- Leaves a documented hook to also attach SBOMs in the existing `docker-publish-*.yml`
+  workflows if per-image SBOMs are wanted later.
+
+## Error Handling / Edge Cases
+
+- Vuln gate fails CI **only** on findings absent from `.osv-scanner.toml`. Allowlisted items
+  carry a human reason and a review date.
+- Honors the project's "no red CI" rule and the existing unfixable-upstream constraint by
+  making suppression explicit and auditable rather than silently non-blocking.
+- SBOM artifact is uploaded even when the scan step fails, so findings are inspectable.
+- `deptry` false positives handled via its ignore config, not by disabling the check.
+
+## Verification
+
+- `make sbom` produces a valid CycloneDX JSON locally.
+- `make security` runs `bandit` + `osv-scanner` clean against the allowlist.
+- `make deps-audit` (`deptry`) exits 0 after pruning.
+- A temporarily injected known-vuln dependency proves the gate **fires**; adding it to
+  `.osv-scanner.toml` proves suppression **works**; both reverted before merge.
+- Full suite green: `make validate` (lint + mypy + test) + `make security` + `make sbom`.
+
+## Affected Files (anticipated)
+
+- `pyproject.toml` — remove `langsmith`, `chromadb` (verify), `safety`; add `deptry`,
+  `cyclonedx-py`; add `[tool.deptry]` config.
+- `.github/dependabot.yml` — groups + caps + github-actions ecosystem.
+- `.github/workflows/security.yml` — **new**.
+- `Makefile` — `sbom`, `deps-audit` targets; rewrite `security`; drop `safety` branches/cleanup.
+- `.osv-scanner.toml` — **new** (allowlist).
+- `.gitignore` — ignore `sbom.cdx.json` (build artifact).
+- `uv.lock` — regenerated.
+
+## Open Items for Implementation Plan
+
+- Confirm `crewai` resolved range keeps `chromadb` available before dropping the pin.
+- Confirm `lxml-html-clean` runtime requirement (keep vs remove).
+- Decide `cyclonedx-py` install (`dev` dep vs `uvx`) and pin policy.
+- Decide release-attach lives in `security.yml` vs a new `release.yml`.

--- a/docs/superpowers/specs/2026-06-07-lean-deps-and-sbom-design.md
+++ b/docs/superpowers/specs/2026-06-07-lean-deps-and-sbom-design.md
@@ -105,7 +105,7 @@ article-extraction behavior and deserves its own change + verification.
 
 | Dep | Evidence | Action |
 |---|---|---|
-| `pendulum` | test | Used only in `tests/test_advanced_libraries.py`, which tests faker+pendulum *themselves*, not project code | Remove dep + that meta-test (optional) |
+| `pendulum` | Used only in `tests/test_advanced_libraries.py`, which tests faker+pendulum *themselves*, not project code | Remove dep + that meta-test (optional) |
 
 **1e. Keep (verified, with rationale):**
 

--- a/docs/superpowers/specs/2026-06-07-lean-deps-and-sbom-design.md
+++ b/docs/superpowers/specs/2026-06-07-lean-deps-and-sbom-design.md
@@ -80,6 +80,12 @@ and non-import usages (CLI tools, pytest plugins/fixtures, MCP/config strings).
 |---|---|---|
 | `markdownify` | `src/epic_news/app.py:51` — optional import with an existing BeautifulSoup fallback | **Drop the optional branch** (fallback already covers it) → no new dep |
 | `tabulate` | `scripts/optimize_crews.py:18` | **Declare in `dev` group** (script-only utility) |
+| `urllib3` | `tools/email_base.py:8`, `tools/github_base.py:8`, `tools/search_base.py:8` — direct import, only transitively present via `requests` | **Declare in runtime** (zero new resolved packages; fixes latent breakage) |
+| `python-dateutil` (`dateutil`) | `tools/unified_rss_tool.py:10` — direct import, only transitively present via `pandas` | **Declare in runtime** (zero new resolved packages) |
+
+> Declaring `urllib3`/`python-dateutil` adds **no** new packages to the resolved tree (already
+> installed transitively) — it just makes the direct import honest and keeps `deptry` green
+> without DEP003 suppression.
 
 **1c. Biggest lean win (follow-up — touches scraping behavior, NOT this pass):**
 
@@ -133,18 +139,30 @@ Rewrite `.github/dependabot.yml`:
 
 ### 4. SBOM generation
 
-- Add `cyclonedx-py` to the `dev` group (or run via `uvx` — decided at plan time).
-- `make sbom` → `cyclonedx-py uv --output-format JSON -o sbom.cdx.json`.
-- `sbom.cdx.json` is a build artifact: git-ignored locally, produced fresh in CI.
+**Validated** (`cyclonedx-bom` 7.3.0 has **no** `uv` subcommand; verified end-to-end producing
+a CycloneDX 1.6 SBOM with 236 runtime components). Run `cyclonedx-py` via `uvx` (zero lockfile
+weight). `make sbom`:
 
-> **API note:** exact `cyclonedx-py` and `osv-scanner` CLI flags are validated against current
-> docs (via context7 / official docs) during implementation before code is written.
+```bash
+uv export --no-dev --no-emit-project --no-hashes --format requirements.txt -o sbom-requirements.txt
+uvx --from cyclonedx-bom cyclonedx-py requirements sbom-requirements.txt \
+    --output-format JSON --spec-version 1.6 --output-file sbom.cdx.json
+```
+
+- `--no-dev` excludes the dev group; the `test` extra is an optional-dependency not exported by
+  default → SBOM is runtime-only (the shipped surface). `sbom.cdx.json` is a build artifact:
+  git-ignored locally, produced fresh in CI. Filename **must** end `.cdx.json` (osv-scanner
+  auto-detects CycloneDX SBOMs by that suffix).
 
 ### 5. Vuln scanning (replaces `safety`)
 
-- Add `.osv-scanner.toml` with documented `[[IgnoredVulns]]` entries (id + `reason` + review
-  date), seeded with the known unfixable `litellm`/`pydantic`/`crewai` chain if it surfaces a CVE.
-- Rewrite `make security`: `bandit -r src` + `osv-scanner --sbom sbom.cdx.json`.
+**Validated** against osv-scanner v2.3.8 docs.
+
+- Add **`osv-scanner.toml`** (no leading dot — that's the auto-discovered name) with documented
+  `[[IgnoredVulns]]` entries: `id`, `reason`, optional `ignoreUntil = YYYY-MM-DD`. Seeded with the
+  known unfixable `litellm`/`pydantic`/`crewai` chain if/when it surfaces a CVE.
+- Rewrite `make security`: `bandit -r src` + `osv-scanner scan source -L sbom.cdx.json --config=osv-scanner.toml`
+  (SBOM passed via `-L`; osv-scanner exits non-zero on un-ignored findings → natural gate).
 - **Remove `safety`:** dev dependency, Makefile branches, and `safety-report.json` cleanup.
 
 ### 6. CI workflow
@@ -166,7 +184,7 @@ New `.github/workflows/security.yml`:
 
 ## Error Handling / Edge Cases
 
-- Vuln gate fails CI **only** on findings absent from `.osv-scanner.toml`. Allowlisted items
+- Vuln gate fails CI **only** on findings absent from `osv-scanner.toml`. Allowlisted items
   carry a human reason and a review date.
 - Honors the project's "no red CI" rule and the existing unfixable-upstream constraint by
   making suppression explicit and auditable rather than silently non-blocking.
@@ -181,7 +199,7 @@ New `.github/workflows/security.yml`:
 - `make security` runs `bandit` + `osv-scanner` clean against the allowlist.
 - `make deps-audit` (`deptry`) exits 0 after pruning.
 - A temporarily injected known-vuln dependency proves the gate **fires**; adding it to
-  `.osv-scanner.toml` proves suppression **works**; both reverted before merge.
+  `osv-scanner.toml` proves suppression **works**; both reverted before merge.
 - Full suite green: `make validate` (lint + mypy + test) + `make security` + `make sbom`.
 
 ## Affected Files (anticipated)
@@ -193,7 +211,7 @@ New `.github/workflows/security.yml`:
 - `.github/dependabot.yml` — groups + caps + github-actions ecosystem.
 - `.github/workflows/security.yml` — **new**.
 - `Makefile` — `sbom`, `deps-audit` targets; rewrite `security`; drop `safety` branches/cleanup.
-- `.osv-scanner.toml` — **new** (allowlist).
+- `osv-scanner.toml` — **new** (allowlist).
 - `.gitignore` — ignore `sbom.cdx.json` (build artifact).
 - `uv.lock` — regenerated.
 - **Follow-up change (separate):** `newspaper3k` → `trafilatura`, then drop `lxml` +
@@ -203,7 +221,7 @@ New `.github/workflows/security.yml`:
 
 - Confirm nothing breaks after dropping the `chromadb` direct pin (transitive via `crewai`).
 - Confirm `markdownify`-branch removal leaves `app.py` markdown handling correct (fallback path).
-- Decide whether to drop `pendulum` + its meta-test in this pass or defer.
-- Decide `cyclonedx-py` install (`dev` dep vs `uvx`) and pin policy.
-- Decide release-attach lives in `security.yml` vs a new `release.yml`.
+- ~~Decide whether to drop `pendulum`~~ → **resolved:** drop it + its meta-test this pass.
+- ~~Decide `cyclonedx-py` install~~ → **resolved:** run via `uvx --from cyclonedx-bom` (no lockfile weight).
+- Decide release-attach lives in `security.yml` vs a new `release.yml` (plan: in `security.yml`, tag-gated job using `gh release upload`).
 - Follow-up: scope the `newspaper3k`→`trafilatura` migration (extraction-quality parity check).

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,12 @@
+# OSV-Scanner vulnerability allowlist.
+# Each entry MUST carry a reason and SHOULD carry an ignoreUntil review date.
+# Format: https://google.github.io/osv-scanner/configuration/
+#
+# Seed entry (commented) for the known unfixable upstream chain documented in
+# pyproject.toml (crewai 1.14.x <-> pydantic <-> litellm). Uncomment and set the
+# real OSV id + expiry if/when osv-scanner reports it and no fix is available.
+#
+# [[IgnoredVulns]]
+# id = "GHSA-xxxx-xxxx-xxxx"
+# ignoreUntil = 2026-09-01
+# reason = "Transitive via crewai 1.14.x pydantic/litellm pin; no compatible fix upstream yet."

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -2,11 +2,20 @@
 # Each entry MUST carry a reason and SHOULD carry an ignoreUntil review date.
 # Format: https://google.github.io/osv-scanner/configuration/
 #
-# Seed entry (commented) for the known unfixable upstream chain documented in
-# pyproject.toml (crewai 1.14.x <-> pydantic <-> litellm). Uncomment and set the
-# real OSV id + expiry if/when osv-scanner reports it and no fix is available.
-#
+# Template for new entries:
 # [[IgnoredVulns]]
 # id = "GHSA-xxxx-xxxx-xxxx"
 # ignoreUntil = 2026-09-01
-# reason = "Transitive via crewai 1.14.x pydantic/litellm pin; no compatible fix upstream yet."
+# reason = "<why this is safe/unavoidable; when to re-evaluate>"
+
+[[IgnoredVulns]]
+id = "GHSA-f4j7-r4q5-qw2c"  # CVE-2026-45829 — chromadb pre-auth RCE (CVSS 9.3)
+ignoreUntil = 2026-09-07
+reason = """
+Critical code-injection in ChromaDB's network SERVER API \
+(/api/v2/.../collections with trust_remote_code), affecting chromadb 1.0.0-1.5.9 \
+with NO patched version available. epic_news does not run a ChromaDB server and \
+does not import chromadb directly (0 imports); it is a forced transitive dependency \
+of crewai (chromadb~=1.1.0) used only as an embedded library, so the vulnerable \
+network endpoint is never exposed. Re-evaluate when chromadb ships a fix or crewai \
+relaxes the pin."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,7 +192,6 @@ dev = [
     "ruff>=0.12.1",
     "mypy>=1.20.1",
     "bandit>=1.9.2",
-    "safety>=3.8.1",
     "tabulate>=0.9.0",
     "yamllint>=1.37.1",
     "yamlfix>=1.17.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
     "pyyaml>=6.0.2",
     "unidecode>=1.4.0",
     # --- HTTP / Web ---
+    "urllib3>=2.0.0",
     "requests>=2.34.0",
     "requests-cache>=1.3.2",
     "httpx>=0.27.2",
@@ -29,6 +30,7 @@ dependencies = [
     "uvicorn>=0.48.0",
     "streamlit>=1.46.0",
     # --- Data sources / scraping ---
+    "python-dateutil>=2.9.0",
     "beautifulsoup4>=4.13.4,<4.14",  # capped by crewai-tools>=1.14.3
     "lxml>=6.1.0",
     "lxml-html-clean>=0.4.2",
@@ -191,6 +193,7 @@ dev = [
     "mypy>=1.20.1",
     "bandit>=1.9.2",
     "safety>=3.8.1",
+    "tabulate>=0.9.0",
     "yamllint>=1.37.1",
     "yamlfix>=1.17.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,7 +250,8 @@ DEP002 = [
     "pytest-cov", "pytest-asyncio", "pytest-env", "pytest-mock",
     "pytest-regressions", "pytest-datadir", "coverage",
 ]
-# DEP003: editable self-install shows up as transitive — it is first-party.
+# DEP003: `pip install -e .` makes epic_news appear in the resolver's transitive
+# output, so suppress it here even though known_first_party already marks it.
 DEP003 = ["epic_news"]
 
 # quoted-strings (exiger les guillemets pour les chaînes multi-lignes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -196,6 +196,7 @@ dev = [
     "tabulate>=0.9.0",
     "yamllint>=1.37.1",
     "yamlfix>=1.17.0",
+    "deptry>=0.20.0",
 ]
 
 [tool.mypy]
@@ -228,6 +229,29 @@ skips = [
     "B101",  # assert_used - commonly used in tests
     "B601",  # paramiko_calls - if using paramiko legitimately
 ]
+
+[tool.deptry]
+known_first_party = ["epic_news"]
+# Treat the `test` optional-dependency group as dev so test-only libs are not
+# flagged as unused in the runtime source.
+optional_dependencies_dev_groups = ["test"]
+# Exclude dev-utility scripts from scanning — they legitimately use dev deps.
+extend_exclude = ["scripts/"]
+
+[tool.deptry.per_rule_ignores]
+# DEP002: declared but not imported in our source — intentional.
+DEP002 = [
+    "litellm",          # LLM backend used by crewai at runtime; CVE-floor pin, not imported
+    "uvicorn",          # ASGI server invoked via CLI (Dockerfile.api, Makefile)
+    "lxml",             # required transitively by newspaper3k at runtime
+    "lxml-html-clean",  # required by newspaper3k (lxml.html.clean split-out)
+    "wikipedia-mcp-server",  # launched via MCP config command string, not imported
+    # pytest plugins / CLI tools (used via fixtures or config, never imported)
+    "pytest-cov", "pytest-asyncio", "pytest-env", "pytest-mock",
+    "pytest-regressions", "pytest-datadir", "coverage",
+]
+# DEP003: editable self-install shows up as transitive — it is first-party.
+DEP003 = ["epic_news"]
 
 # quoted-strings (exiger les guillemets pour les chaînes multi-lignes)
 # quoted-strings = { required = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "composio-crewai>=0.7.18",
     "litellm>=1.87.0",  # CVE fix blocked upstream: crewai 1.14.x needs pydantic<2.12, litellm 1.83.7+ needs ==2.12.5
     "langfuse>=3.2.3",
-    "chromadb>=0.5.23",
     # --- Pydantic / data ---
     "pydantic>=2.7.0",
     "loguru>=0.7.3",
@@ -73,8 +72,6 @@ test = [
     "coverage>=7.14.0",
     "freezegun>=1.5.2",
     "faker>=37.4.0",
-    "pendulum>=3.1.0",
-    "langsmith",
 ]
 
 [tool.crewai]
@@ -194,7 +191,6 @@ dev = [
     "mypy>=1.20.1",
     "bandit>=1.9.2",
     "safety>=3.8.1",
-    "vulture>=2.14",
     "yamllint>=1.37.1",
     "yamlfix>=1.17.0",
 ]

--- a/src/epic_news/app.py
+++ b/src/epic_news/app.py
@@ -43,24 +43,17 @@ logger.add(StreamlitLogSink(log_queue), format="{time:YYYY-MM-DD HH:mm:ss} - {le
 def html_to_markdown(html: str) -> str:
     """Best-effort HTML→Markdown conversion for displaying/downloading.
 
-    Tries `markdownify` if available; falls back to BeautifulSoup text extraction;
-    finally returns original HTML if no converters are available.
+    Uses BeautifulSoup text extraction; returns original HTML on failure.
     """
     try:
-        # Prefer markdownify when present
-        from markdownify import markdownify as md
+        from bs4 import BeautifulSoup
 
-        return str(md(html, heading_style="ATX"))
+        soup = BeautifulSoup(html, "html.parser")
+        # Keep basic structure using newlines
+        text = soup.get_text("\n")
+        return text.strip()
     except Exception:
-        try:
-            from bs4 import BeautifulSoup
-
-            soup = BeautifulSoup(html, "html.parser")
-            # Keep basic structure using newlines
-            text = soup.get_text("\n")
-            return text.strip()
-        except Exception:
-            return html
+        return html
 
 
 # --- Crew Execution Logic ---

--- a/src/epic_news/app.py
+++ b/src/epic_news/app.py
@@ -41,7 +41,7 @@ logger.add(StreamlitLogSink(log_queue), format="{time:YYYY-MM-DD HH:mm:ss} - {le
 
 # --- Helpers ---
 def html_to_markdown(html: str) -> str:
-    """Best-effort HTML→Markdown conversion for displaying/downloading.
+    """Best-effort HTML→plain-text conversion for displaying/downloading.
 
     Uses BeautifulSoup text extraction; returns original HTML on failure.
     """

--- a/src/epic_news/app.py
+++ b/src/epic_news/app.py
@@ -3,6 +3,7 @@ from queue import Empty, Queue
 from threading import Thread
 
 import streamlit as st
+from bs4 import BeautifulSoup
 from loguru import logger
 
 from epic_news.main import kickoff
@@ -46,8 +47,6 @@ def html_to_markdown(html: str) -> str:
     Uses BeautifulSoup text extraction; returns original HTML on failure.
     """
     try:
-        from bs4 import BeautifulSoup
-
         soup = BeautifulSoup(html, "html.parser")
         # Keep basic structure using newlines
         text = soup.get_text("\n")

--- a/tests/test_advanced_libraries.py
+++ b/tests/test_advanced_libraries.py
@@ -1,19 +1,3 @@
-import pendulum
-from faker import Faker
-
-
-def test_faker_and_pendulum():
-    """
-    This test demonstrates the use of Faker and Pendulum.
-    """
-    fake = Faker()
-    name = fake.name()
-    now = pendulum.now()
-
-    assert isinstance(name, str)
-    assert isinstance(now, pendulum.DateTime)
-
-
 def test_mocking_with_pytest_mock(mocker):
     """
     This test demonstrates the use of pytest-mock.

--- a/tests/test_html_to_markdown.py
+++ b/tests/test_html_to_markdown.py
@@ -18,3 +18,10 @@ def test_html_to_markdown_handles_garbage_gracefully():
     assert html_to_markdown("") == ""
     # Plain text with no tags passes through unchanged.
     assert html_to_markdown("just plain text") == "just plain text"
+
+
+def test_html_to_markdown_returns_raw_html_on_parse_failure(mocker):
+    # If the parser raises, the original HTML is returned unchanged (fallback path).
+    mocker.patch("epic_news.app.BeautifulSoup", side_effect=ValueError("boom"))
+    raw = "<p>unchanged</p>"
+    assert html_to_markdown(raw) == raw

--- a/tests/test_html_to_markdown.py
+++ b/tests/test_html_to_markdown.py
@@ -8,6 +8,9 @@ def test_html_to_markdown_extracts_text():
     assert "Hello" in result
     assert "world" in result
     assert "<" not in result  # tags stripped
+    assert (
+        result == "Title\nHello \nworld"
+    )  # exact extracted text (bs4 preserves trailing space in text node)
 
 
 def test_html_to_markdown_handles_garbage_gracefully():

--- a/tests/test_html_to_markdown.py
+++ b/tests/test_html_to_markdown.py
@@ -1,0 +1,15 @@
+from epic_news.app import html_to_markdown
+
+
+def test_html_to_markdown_extracts_text():
+    html = "<h1>Title</h1><p>Hello <b>world</b></p>"
+    result = html_to_markdown(html)
+    assert "Title" in result
+    assert "Hello" in result
+    assert "world" in result
+    assert "<" not in result  # tags stripped
+
+
+def test_html_to_markdown_handles_garbage_gracefully():
+    # Non-HTML input must not raise.
+    assert isinstance(html_to_markdown(""), str)

--- a/tests/test_html_to_markdown.py
+++ b/tests/test_html_to_markdown.py
@@ -14,5 +14,7 @@ def test_html_to_markdown_extracts_text():
 
 
 def test_html_to_markdown_handles_garbage_gracefully():
-    # Non-HTML input must not raise.
-    assert isinstance(html_to_markdown(""), str)
+    # Empty input must not raise and returns an empty string.
+    assert html_to_markdown("") == ""
+    # Plain text with no tags passes through unchanged.
+    assert html_to_markdown("just plain text") == "just plain text"

--- a/uv.lock
+++ b/uv.lock
@@ -906,18 +906,6 @@ wheels = [
 ]
 
 [[package]]
-name = "dparse"
-version = "0.6.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "packaging" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/29/ee/96c65e17222b973f0d3d0aa9bad6a59104ca1b0eb5b659c25c2900fccd85/dparse-0.6.4.tar.gz", hash = "sha256:90b29c39e3edc36c6284c82c4132648eaf28a01863eb3c231c2512196132201a", size = 27912, upload-time = "2024-11-08T16:52:06.444Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/26/035d1c308882514a1e6ddca27f9d3e570d67a0e293e7b4d910a70c8fe32b/dparse-0.6.4-py3-none-any.whl", hash = "sha256:fbab4d50d54d0e739fbb4dedfc3d92771003a5b9aa8545ca7a7045e3b174af57", size = 11925, upload-time = "2024-11-08T16:52:03.844Z" },
-]
-
-[[package]]
 name = "durationpy"
 version = "0.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1003,7 +991,6 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "ruff" },
-    { name = "safety" },
     { name = "tabulate" },
     { name = "yamlfix" },
     { name = "yamllint" },
@@ -1067,7 +1054,6 @@ dev = [
     { name = "mypy", specifier = ">=1.20.1" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "ruff", specifier = ">=0.12.1" },
-    { name = "safety", specifier = ">=3.8.1" },
     { name = "tabulate", specifier = ">=0.9.0" },
     { name = "yamlfix", specifier = ">=1.17.0" },
     { name = "yamllint", specifier = ">=1.37.1" },
@@ -2063,15 +2049,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
     { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
     { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
-]
-
-[[package]]
-name = "marshmallow"
-version = "4.3.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/25/7e/1dbd4096eb7c148cd2841841916f78820bb85a4d80a0c25c02d30815a7fb/marshmallow-4.3.0.tar.gz", hash = "sha256:fb43c53b3fe240b8f6af37223d6ef1636f927ad9bea8ab323afad95dff090880", size = 224485, upload-time = "2026-04-03T21:46:32.72Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/e0/ff24e25218bb59eb6290a530cea40651b14068b6e3659b20f9c175179632/marshmallow-4.3.0-py3-none-any.whl", hash = "sha256:46c4fe6984707e3cbd485dfebbf0a59874f58d695aad05c1668d15e8c6e13b46", size = 49148, upload-time = "2026-04-03T21:46:31.241Z" },
 ]
 
 [[package]]
@@ -3513,15 +3490,6 @@ wheels = [
 ]
 
 [[package]]
-name = "ruamel-yaml"
-version = "0.19.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c7/3b/ebda527b56beb90cb7652cb1c7e4f91f48649fbcd8d2eb2fb6e77cd3329b/ruamel_yaml-0.19.1.tar.gz", hash = "sha256:53eb66cd27849eff968ebf8f0bf61f46cdac2da1d1f3576dd4ccee9b25c31993", size = 142709, upload-time = "2026-01-02T16:50:31.84Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/0c/51f6841f1d84f404f92463fc2b1ba0da357ca1e3db6b7fbda26956c3b82a/ruamel_yaml-0.19.1-py3-none-any.whl", hash = "sha256:27592957fedf6e0b62f281e96effd28043345e0e66001f97683aa9a40c667c93", size = 118102, upload-time = "2026-01-02T16:50:29.201Z" },
-]
-
-[[package]]
 name = "ruff"
 version = "0.15.15"
 source = { registry = "https://pypi.org/simple" }
@@ -3557,51 +3525,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4b/75/abbc7eab08bad7f47887a0555d3ac9e3947f89d2416678c08e025e449fdc/ruyaml-0.91.0.tar.gz", hash = "sha256:6ce9de9f4d082d696d3bde264664d1bcdca8f5a9dff9d1a1f1a127969ab871ab", size = 239075, upload-time = "2021-12-07T16:19:58.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/9a/16ca152a04b231c179c626de40af1d5d0bc2bc57bc875c397706016ddb2b/ruyaml-0.91.0-py3-none-any.whl", hash = "sha256:50e0ee3389c77ad340e209472e0effd41ae0275246df00cdad0a067532171755", size = 108906, upload-time = "2021-12-07T16:19:56.798Z" },
-]
-
-[[package]]
-name = "safety"
-version = "3.8.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "authlib" },
-    { name = "certifi" },
-    { name = "click" },
-    { name = "dparse" },
-    { name = "filelock" },
-    { name = "httpx" },
-    { name = "jinja2" },
-    { name = "marshmallow" },
-    { name = "nltk" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "ruamel-yaml" },
-    { name = "safety-schemas" },
-    { name = "tenacity" },
-    { name = "tomlkit" },
-    { name = "truststore" },
-    { name = "typer" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/7b/8e1d580c5178f0736b806b7199827e61e2a2569eec5b49ec75da6273bbdf/safety-3.8.1.tar.gz", hash = "sha256:e646123b976bbb6707cfaacae8c926e2f886b744a60e0f410e8610a3a4eaf7be", size = 412947, upload-time = "2026-05-29T15:09:33.355Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/f5/498db84333a644835e572c0d96cfa705bf9871f863289a7845082d54755e/safety-3.8.1-py3-none-any.whl", hash = "sha256:953c1c3c60c873f53a6cc250b2a9c4b38bb6ef45f0625990e43f20bff916c965", size = 340521, upload-time = "2026-05-29T15:09:31.622Z" },
-]
-
-[[package]]
-name = "safety-schemas"
-version = "0.0.16"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "dparse" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "ruamel-yaml" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/ef/0e07dfdb4104c4e42ae9fc6e8a0da7be2d72ac2ee198b32f7500796de8f3/safety_schemas-0.0.16.tar.gz", hash = "sha256:3bb04d11bd4b5cc79f9fa183c658a6a8cf827a9ceec443a5ffa6eed38a50a24e", size = 54815, upload-time = "2025-09-16T14:35:31.973Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/a2/7840cc32890ce4b84668d3d9dfe15a48355b683ae3fb627ac97ac5a4265f/safety_schemas-0.0.16-py3-none-any.whl", hash = "sha256:6760515d3fd1e6535b251cd73014bd431d12fe0bfb8b6e8880a9379b5ab7aa44", size = 39292, upload-time = "2025-09-16T14:35:32.84Z" },
 ]
 
 [[package]]
@@ -3921,15 +3844,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tomlkit"
-version = "0.15.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/db/03eaf4331631ef6b27d6e3c9b68c54dc6f0d63d87201fed600cc409307fd/tomlkit-0.15.0.tar.gz", hash = "sha256:7d1a9ecba3086638211b13814ea79c90dd54dd11993564376f3aa92271f5c7a3", size = 161875, upload-time = "2026-05-10T07:38:22.245Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/43/8bd850ee71a191bf072e31302c73a66be413fecdd98fdcd111ecbcce13ca/tomlkit-0.15.0-py3-none-any.whl", hash = "sha256:4dbc8f0fc024412b57ced8757ac7461305126a648ff8c2c807fcb8e133a78738", size = 41328, upload-time = "2026-05-10T07:38:23.517Z" },
-]
-
-[[package]]
 name = "tqdm"
 version = "4.67.3"
 source = { registry = "https://pypi.org/simple" }
@@ -3939,15 +3853,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
-]
-
-[[package]]
-name = "truststore"
-version = "0.10.4"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -942,6 +942,7 @@ dependencies = [
     { name = "pandas" },
     { name = "pyairtable" },
     { name = "pydantic" },
+    { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
     { name = "requests" },
@@ -950,6 +951,7 @@ dependencies = [
     { name = "tavily-python" },
     { name = "tenacity" },
     { name = "unidecode" },
+    { name = "urllib3" },
     { name = "uvicorn" },
     { name = "weasyprint" },
     { name = "wikipedia" },
@@ -978,6 +980,7 @@ dev = [
     { name = "pre-commit" },
     { name = "ruff" },
     { name = "safety" },
+    { name = "tabulate" },
     { name = "yamlfix" },
     { name = "yamllint" },
 ]
@@ -1015,6 +1018,7 @@ requires-dist = [
     { name = "pytest-env", marker = "extra == 'test'", specifier = ">=1.1.5" },
     { name = "pytest-mock", marker = "extra == 'test'", specifier = ">=3.14.1" },
     { name = "pytest-regressions", marker = "extra == 'test'", specifier = ">=2.10.0" },
+    { name = "python-dateutil", specifier = ">=2.9.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "pyyaml", specifier = ">=6.0.2" },
     { name = "requests", specifier = ">=2.34.0" },
@@ -1023,6 +1027,7 @@ requires-dist = [
     { name = "tavily-python", specifier = ">=0.7.24" },
     { name = "tenacity", specifier = ">=8.2.3" },
     { name = "unidecode", specifier = ">=1.4.0" },
+    { name = "urllib3", specifier = ">=2.0.0" },
     { name = "uvicorn", specifier = ">=0.48.0" },
     { name = "weasyprint", specifier = ">=69.0" },
     { name = "wikipedia", specifier = ">=1.4.0" },
@@ -1038,6 +1043,7 @@ dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "ruff", specifier = ">=0.12.1" },
     { name = "safety", specifier = ">=3.8.1" },
+    { name = "tabulate", specifier = ">=0.9.0" },
     { name = "yamlfix", specifier = ">=1.17.0" },
     { name = "yamllint", specifier = ">=1.37.1" },
 ]
@@ -3701,6 +3707,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/91/74/20dac6d6200d6ec0e1c230fb8eeb6a1a423645eacb76e8d802adfc246456/streamlit-1.58.0.tar.gz", hash = "sha256:78a22e7085b053af7ce544442bf4b670771e68c509ba1bdaa056ba0708f49c3d", size = 8721149, upload-time = "2026-05-28T18:02:44.606Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/84/14c36a92fb24f8e1cea452f53b0744b5da69d52cdd2fe22e71e6fbf765d5/streamlit-1.58.0-py3-none-any.whl", hash = "sha256:4ca8a7afc5bd16a5f176ccf4be1e34e8121cad0240becd127fb58a103ea3178d", size = 9219185, upload-time = "2026-05-28T18:02:41.993Z" },
+]
+
+[[package]]
+name = "tabulate"
+version = "0.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/58/8c37dea7bbf769b20d58e7ace7e5edfe65b849442b00ffcdd56be88697c6/tabulate-0.10.0.tar.gz", hash = "sha256:e2cfde8f79420f6deeffdeda9aaec3b6bc5abce947655d17ac662b126e48a60d", size = 91754, upload-time = "2026-03-04T18:55:34.402Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/99/55/db07de81b5c630da5cbf5c7df646580ca26dfaefa593667fc6f2fe016d2e/tabulate-0.10.0-py3-none-any.whl", hash = "sha256:f0b0622e567335c8fabaaa659f1b33bcb6ddfe2e496071b743aa113f8774f2d3", size = 39814, upload-time = "2026-03-04T18:55:31.284Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -847,6 +847,29 @@ wheels = [
 ]
 
 [[package]]
+name = "deptry"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "packaging" },
+    { name = "requirements-parser" },
+    { name = "tomli" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/b2/50ccc99362ae7757342978b7ecb3b98e47fade721fd617d74db1948ec3a1/deptry-0.25.1.tar.gz", hash = "sha256:45c8cd982c85cd4faae573ddff6920de7eec735336db6973f26a765ae7950f7d", size = 509748, upload-time = "2026-03-18T23:22:18.139Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/1d/b538dc635e873b25360d761cfe1fa0ccd7d6c69b698047e552f33401e60d/deptry-0.25.1-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a4dd1148db24a1ddacfa8b840836c6019c2f864fcb7579dd089fd217606338c8", size = 1850319, upload-time = "2026-03-18T23:22:15.65Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/a9/511477a8f0ae4f6021d68a80bdca77e7ffb0722008dc24ee5d9ef49f5c88/deptry-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c67c666d916ef12013c0772e40d78be0f21577a495d8d99ec5fcb18c332d393d", size = 1759259, upload-time = "2026-03-18T23:22:30.853Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/4b/c9f0bdda410912a6df79a789cb118fa29acae02a397794ead3c84adcda5c/deptry-0.25.1-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:58d39279828dbf4efc1abb40bf50a71b21499c36759bed5a8d8a3c0e3149b091", size = 1872012, upload-time = "2026-03-18T23:22:19.145Z" },
+    { url = "https://files.pythonhosted.org/packages/72/9c/6f6f9125bac74b5d5d2af89536cbdb3fa159b6466aa097b74e7e85e8e030/deptry-0.25.1-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:14bfcc28b4326ed8c6abb30691b19077d4ef8613cfba6c37ef5b1f471775bf6f", size = 1926575, upload-time = "2026-03-18T23:22:11.269Z" },
+    { url = "https://files.pythonhosted.org/packages/52/48/2a5e705a7f898295966ade67bd1223e2af96da433e25b39f6b9483ba2c7b/deptry-0.25.1-cp310-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:555f5f9a487899ec9bf301eecba1745e14d212c4b354f4d3a5fd691e907366d3", size = 2050816, upload-time = "2026-03-18T23:22:27.439Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/c6/50f189a894e1f3bf21266299112c8a06cb731838976e1b9a9cadd0b4a86e/deptry-0.25.1-cp310-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:18d21b3545ab2bfec53f3f45c6f5f201d55f713323327f8d12674505469ae6b7", size = 2145416, upload-time = "2026-03-18T23:22:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/6a/3f82f7a06217778282bc4456af1b4ffb3bc4b2c8e7891d00e8323f9ad0b8/deptry-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:b59a560cb7dffb21832a98bb80d33d614cfb5630ea36ce21833eabf4eae3df99", size = 1718489, upload-time = "2026-03-18T23:22:28.589Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/7f/cd6b3ac8cf95f2f1c5c7a74ff6452e9098af89a9b56607381f677880641e/deptry-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:6efffd8116fb9d2c45a251382ce4ce1c38dbb17179f581ec9231ed5390f7fc12", size = 1647020, upload-time = "2026-03-18T23:22:23.311Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
@@ -976,6 +999,7 @@ test = [
 [package.dev-dependencies]
 dev = [
     { name = "bandit" },
+    { name = "deptry" },
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "ruff" },
@@ -1039,6 +1063,7 @@ provides-extras = ["test"]
 [package.metadata.requires-dev]
 dev = [
     { name = "bandit", specifier = ">=1.9.2" },
+    { name = "deptry", specifier = ">=0.20.0" },
     { name = "mypy", specifier = ">=1.20.1" },
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "ruff", specifier = ">=0.12.1" },
@@ -3410,6 +3435,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "requirements-parser"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/95/96/fb6dbfebb524d5601d359a47c78fe7ba1eef90fc4096404aa60c9a906fbb/requirements_parser-0.13.0.tar.gz", hash = "sha256:0843119ca2cb2331de4eb31b10d70462e39ace698fd660a915c247d2301a4418", size = 22630, upload-time = "2025-05-21T13:42:05.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/60/50fbb6ffb35f733654466f1a90d162bcbea358adc3b0871339254fbc37b2/requirements_parser-0.13.0-py3-none-any.whl", hash = "sha256:2b3173faecf19ec5501971b7222d38f04cb45bb9d87d0ad629ca71e2e62ded14", size = 14782, upload-time = "2025-05-21T13:42:04.007Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -922,7 +922,6 @@ version = "3.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
-    { name = "chromadb" },
     { name = "composio" },
     { name = "composio-crewai" },
     { name = "crewai" },
@@ -963,8 +962,6 @@ test = [
     { name = "coverage" },
     { name = "faker" },
     { name = "freezegun" },
-    { name = "langsmith" },
-    { name = "pendulum" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -981,7 +978,6 @@ dev = [
     { name = "pre-commit" },
     { name = "ruff" },
     { name = "safety" },
-    { name = "vulture" },
     { name = "yamlfix" },
     { name = "yamllint" },
 ]
@@ -989,7 +985,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.13.4,<4.14" },
-    { name = "chromadb", specifier = ">=0.5.23" },
     { name = "composio", specifier = ">=0.1.1" },
     { name = "composio-crewai", specifier = ">=0.7.18" },
     { name = "coverage", marker = "extra == 'test'", specifier = ">=7.14.0" },
@@ -1003,7 +998,6 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27.2" },
     { name = "jinja2", specifier = ">=3.1.3" },
     { name = "langfuse", specifier = ">=3.2.3" },
-    { name = "langsmith", marker = "extra == 'test'" },
     { name = "litellm", specifier = ">=1.87.0" },
     { name = "loguru", specifier = ">=0.7.3" },
     { name = "lxml", specifier = ">=6.1.0" },
@@ -1012,7 +1006,6 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.26.0" },
     { name = "newspaper3k", specifier = ">=0.2.8" },
     { name = "pandas", specifier = ">=3.0.3" },
-    { name = "pendulum", marker = "extra == 'test'", specifier = ">=3.1.0" },
     { name = "pyairtable", specifier = ">=3.1.1" },
     { name = "pydantic", specifier = ">=2.7.0" },
     { name = "pytest", marker = "extra == 'test'", specifier = ">=8.4.0" },
@@ -1045,7 +1038,6 @@ dev = [
     { name = "pre-commit", specifier = ">=4.2.0" },
     { name = "ruff", specifier = ">=0.12.1" },
     { name = "safety", specifier = ">=3.8.1" },
-    { name = "vulture", specifier = ">=2.14" },
     { name = "yamlfix", specifier = ">=1.17.0" },
     { name = "yamllint", specifier = ">=1.37.1" },
 ]
@@ -1874,27 +1866,6 @@ wheels = [
 ]
 
 [[package]]
-name = "langsmith"
-version = "0.8.9"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "httpx" },
-    { name = "orjson", marker = "platform_python_implementation != 'PyPy'" },
-    { name = "packaging" },
-    { name = "pydantic" },
-    { name = "requests" },
-    { name = "requests-toolbelt" },
-    { name = "uuid-utils" },
-    { name = "websockets" },
-    { name = "xxhash" },
-    { name = "zstandard" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/e4/dd/f4c8a12987318e505b10760d30c3c2d45e8dc87ba8f47a004c753a9e7b35/langsmith-0.8.9.tar.gz", hash = "sha256:f16e37fcd5a8a2d4db30eae0e399a866a65ce5cc86218825c59409ed57a3bf53", size = 4428684, upload-time = "2026-06-03T17:56:09.448Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/2f/a701663c9fb4d9630448622a684bc372b4905b9a6dbe2297d55a70fde04e/langsmith-0.8.9-py3-none-any.whl", hash = "sha256:c9519cabc75568d088df045710d1b86eae9780c91054528b2aa7e6cb1fc80c52", size = 403165, upload-time = "2026-06-03T17:56:07.226Z" },
-]
-
-[[package]]
 name = "librt"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2650,29 +2621,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/9f/09/a3b2a32ce498f405dce4320267e99b1b076c1ea39ad01151a353bc7f81d7/peewee-4.0.6.tar.gz", hash = "sha256:ea2f78f24ff9e3660281dc5b0be8bc00d9a9514bdc40c98e416fcd042b66ac6a", size = 724591, upload-time = "2026-05-20T13:18:17.26Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/6a/e1455b94ee48f5666f2e7831b6247098794bfe9747da457111be4d0bea10/peewee-4.0.6-py3-none-any.whl", hash = "sha256:5fa665913c410f0b5faef1469ed0aa9eceb9fef262665ebbb6f29408f826eeeb", size = 146222, upload-time = "2026-05-20T13:18:15.694Z" },
-]
-
-[[package]]
-name = "pendulum"
-version = "3.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "python-dateutil" },
-    { name = "tzdata" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/cb/72/9a51afa0a822b09e286c4cb827ed7b00bc818dac7bd11a5f161e493a217d/pendulum-3.2.0.tar.gz", hash = "sha256:e80feda2d10fa3ff8b1526715f7d33dcb7e08494b3088f2c8a3ac92d4a4331ce", size = 86912, upload-time = "2026-01-30T11:22:24.093Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/8c/400c8b8dbd7524424f3d9902ded64741e82e5e321d1aabbd68ade89e71cf/pendulum-3.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:addb0512f919fe5b70c8ee534ee71c775630d3efe567ea5763d92acff857cfc3", size = 337820, upload-time = "2026-01-30T11:21:24.305Z" },
-    { url = "https://files.pythonhosted.org/packages/59/38/7c16f26cc55d9206d71da294ce6857d0da381e26bc9e0c2a069424c2b173/pendulum-3.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:3aaa50342dc174acebdc21089315012e63789353957b39ac83cac9f9fc8d1075", size = 327551, upload-time = "2026-01-30T11:21:25.747Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/cd/f36ec5d56d55104232380fdbf84ff53cc05607574af3cbdc8a43991ac8a7/pendulum-3.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:927e9c9ab52ff68e71b76dd410e5f1cd78f5ea6e7f0a9f5eb549aea16a4d5354", size = 339894, upload-time = "2026-01-30T11:21:27.229Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/4e/b9a1e546519c3a92d5bc17787cea925e06a20def2ae344fa136d2fc40338/pendulum-3.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:249d18f5543c9f43aba3bd77b34864ec8cf6f64edbead405f442e23c94fce63d", size = 373766, upload-time = "2026-01-30T11:21:28.642Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/a6/6471ab87ae2260594501f071586a765fc894817043b7d2d4b04e2eff4f31/pendulum-3.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7c644cc15eec5fb02291f0f193195156780fd5a0affd7a349592403826d1a35e", size = 379837, upload-time = "2026-01-30T11:21:30.637Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/79/0ba0c14e862388f7b822626e6e989163c23bebe7f96de5ec4b207cbe7c3d/pendulum-3.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:063ab61af953bb56ad5bc8e131fd0431c915ed766d90ccecd7549c8090b51004", size = 348904, upload-time = "2026-01-30T11:21:32.436Z" },
-    { url = "https://files.pythonhosted.org/packages/17/34/df922c7c0b12719589d4954bfa5bdca9e02bcde220f5c5c1838a87118960/pendulum-3.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:26a3ae26c9dd70a4256f1c2f51addc43641813574c0db6ce5664f9861cd93621", size = 517173, upload-time = "2026-01-30T11:21:34.428Z" },
-    { url = "https://files.pythonhosted.org/packages/87/ec/3b9e061eeee97b72a47c1434ee03f6d85f0284d9285d92b12b0fff2d19ac/pendulum-3.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:2b10d91dc00f424444a42f47c69e6b3bfd79376f330179dc06bc342184b35f9a", size = 561744, upload-time = "2026-01-30T11:21:35.861Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/7e/f12fdb6070b7975c1fcfa5685dbe4ab73c788878a71f4d1d7e3c87979e37/pendulum-3.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:63070ff03e30a57b16c8e793ee27da8dac4123c1d6e0cf74c460ce9ee8a64aa4", size = 258746, upload-time = "2026-01-30T11:21:37.782Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/b8/5abd872056357f069ae34a9b24a75ac58e79092d16201d779a8dd31386bb/pendulum-3.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:c8dde63e2796b62070a49ce813ce200aba9186130307f04ec78affcf6c2e8122", size = 253028, upload-time = "2026-01-30T11:21:39.381Z" },
-    { url = "https://files.pythonhosted.org/packages/02/fb/d65db067a67df7252f18b0cb7420dda84078b9e8bfb375215469c14a50be/pendulum-3.2.0-py3-none-any.whl", hash = "sha256:f3a9c18a89b4d9ef39c5fa6a78722aaff8d5be2597c129a3b16b9f40a561acf3", size = 114111, upload-time = "2026-01-30T11:22:22.361Z" },
 ]
 
 [[package]]
@@ -3459,18 +3407,6 @@ wheels = [
 ]
 
 [[package]]
-name = "requests-toolbelt"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f3/61/d7545dafb7ac2230c70d38d31cbfe4cc64f7144dc41f6e4e4b78ecd9f5bb/requests-toolbelt-1.0.0.tar.gz", hash = "sha256:7681a0a3d047012b5bdc0ee37d7f8f07ebe76ab08caeccfc3921ce23c88d5bc6", size = 206888, upload-time = "2023-05-01T04:11:33.229Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/51/d4db610ef29373b879047326cbf6fa98b6c1969d6f6dc423279de2b1be2c/requests_toolbelt-1.0.0-py2.py3-none-any.whl", hash = "sha256:cccfdd665f0a24fcf4726e690f65639d272bb0637b9b92dfd91a5568ccf6bd06", size = 54481, upload-time = "2023-05-01T04:11:28.427Z" },
-]
-
-[[package]]
 name = "rich"
 version = "14.3.4"
 source = { registry = "https://pypi.org/simple" }
@@ -4056,42 +3992,6 @@ wheels = [
 ]
 
 [[package]]
-name = "uuid-utils"
-version = "0.16.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/01/a1/822ceef22d1c139cffebe4b1b660cfaa10253d5c770aa2598dc8e9497593/uuid_utils-0.16.0.tar.gz", hash = "sha256:d6902d4375dfba4c9902c736bb82d3c040417b67f7d0fa48910ddfdb1ac95de7", size = 42596, upload-time = "2026-05-19T07:44:23.28Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/60/9b/74c1f47a9b4f138a254e51528e5ffaeba6bf99ecead9f0c4b6fccccfbfcb/uuid_utils-0.16.0-cp313-cp313-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:d34cf9681e8892fad2a63e393068e544505408748cd8bf0c3517d753a01528d4", size = 563166, upload-time = "2026-05-19T07:44:10.494Z" },
-    { url = "https://files.pythonhosted.org/packages/7c/1c/009e37b70f1f0ff17e7103a36bafde33d503d9ea7fe739761aa3e3c9fde6/uuid_utils-0.16.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:0681d1bdb7956e0c6d581e7601dabcfb2b08c25d2a65189f4e9b102c94f5ff46", size = 289529, upload-time = "2026-05-19T07:43:54.466Z" },
-    { url = "https://files.pythonhosted.org/packages/5e/5e/e0323d54321166639eb2be5e8a464f5cb0fc04d72d91f3e78944bb6a1da8/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed45fb8732d216426227096b55accbb87cba57febc86a044d90780b090eb99d0", size = 326328, upload-time = "2026-05-19T07:45:31.901Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/a3/046f6cb958467c3bf4a163a8a53b178b64a62e21ed8ad5b2c1dacb3a2cfc/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b617a334bb01ef2ff8c22900f5a14125eb9063f602131494cc9dc59519beaa5b", size = 332322, upload-time = "2026-05-19T07:43:41.284Z" },
-    { url = "https://files.pythonhosted.org/packages/67/80/01914e3949744db7acd0006885e5542fbebb6e39114857d007d29b3265c2/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a750d8aeb8ae880aa9a2529606bde0e994bcc7448730c953107f357a28e6102e", size = 445787, upload-time = "2026-05-19T07:45:36.102Z" },
-    { url = "https://files.pythonhosted.org/packages/14/ef/f6908f41279f205d70c8a0d5dcb25dd6802741d7f88e3f0123453c3584d3/uuid_utils-0.16.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9a250e111903c4368745fce5ac2aa607bd477c62d3307e45347338fdb64b38e0", size = 324678, upload-time = "2026-05-19T07:45:12.77Z" },
-    { url = "https://files.pythonhosted.org/packages/11/4a/bf841ba90f829c7779d82155e0f4b88ef6726ccc25507d064d50ac2cd329/uuid_utils-0.16.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:95b7f480010ea98a29ee809857a98aa923008c68129af1b39244adccff7377fb", size = 349704, upload-time = "2026-05-19T07:44:47.172Z" },
-    { url = "https://files.pythonhosted.org/packages/e6/31/3b5c60172b8c57bf4ca485484b8e4edef550ca324f9287f1183be97422e2/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:420aa3ca403cedb73490b6ea3aeefeea7e0455f5ce60bbf856390ee872ae3306", size = 502456, upload-time = "2026-05-19T07:45:00.821Z" },
-    { url = "https://files.pythonhosted.org/packages/88/bf/3da8d497af80fd51d8bf85551c77ede67f07825924ec5987bf9b6031014a/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:b8a9a7b1065a12d40f2cc25b7d705ab34954cc57095034367bca39ebcf4a876b", size = 607727, upload-time = "2026-05-19T07:44:30.058Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/4e/7c8cf03ec15cd6f40e4cbab81b2b4a625461327f68c7971e54723280ec3e/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:f235ac5827d74ac630cc87f29278cdaa5d2f273613a6e05bbd96df7aa4170776", size = 566204, upload-time = "2026-05-19T07:44:51.225Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/5f/af955feae69cce7fd2121ca3f790ff4b85ad2e17b2149546f50753e1a047/uuid_utils-0.16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:c8083284488b84ad178e74add64cfd1e74e8be5e30821e5acbc5019281c658b0", size = 529986, upload-time = "2026-05-19T07:45:57.85Z" },
-    { url = "https://files.pythonhosted.org/packages/10/cf/3fec757e51bef10eb41ae8075f5442c60e85ff456b42d16a3063f5dc6c80/uuid_utils-0.16.0-cp313-cp313-pyemscripten_2025_0_wasm32.whl", hash = "sha256:27a071a899ba46a551d6524dbbc5a98b88be176d0f55ddf72cf71c005326ac10", size = 98683, upload-time = "2026-05-19T07:44:16.369Z" },
-    { url = "https://files.pythonhosted.org/packages/40/a7/cd1adbea7ef882a70db064c00cd93b12e11027b4cdd7ffd79e95c35fc3e3/uuid_utils-0.16.0-cp313-cp313-win32.whl", hash = "sha256:924a8de04460e4cf65998ad0b6568084f7c51740ebd3254d07a0bcde35a84af6", size = 168822, upload-time = "2026-05-19T07:44:24.09Z" },
-    { url = "https://files.pythonhosted.org/packages/74/99/617ceb9e3a95b23837012740979baf71afad723b70daf34862da3f7c17a1/uuid_utils-0.16.0-cp313-cp313-win_amd64.whl", hash = "sha256:5279bc7ab3c6683f1c67314695bee14d869015acbbc677bdb0015190fe753d16", size = 174967, upload-time = "2026-05-19T07:44:56.022Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/d8/148ae707bfc36d482e39db679c86b81bdce264d4feb9df5d40a03b7687e3/uuid_utils-0.16.0-cp313-cp313-win_arm64.whl", hash = "sha256:61a9c4c26ad12ac66fa4bfd0fdb8494724fe7a5b98a9fcd43e78e2b388663dbb", size = 173142, upload-time = "2026-05-19T07:43:50.171Z" },
-    { url = "https://files.pythonhosted.org/packages/21/05/ca6d60705e71fdeaa3431dad94e279a8213c5573cb2925e1aabf3dc0330a/uuid_utils-0.16.0-cp313-cp313t-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:73486b6aa3f755a6c97000f5ea67e7ac78d6df89bf22980789a1e943e24b74f0", size = 564408, upload-time = "2026-05-19T07:44:38.351Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/8c/b9a0462c38535c1662acb1025768e2d626bee5ce9e1790bad6b5381162ea/uuid_utils-0.16.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:f1614572fd9345cdc3dde3f40c237345719fabca1aa87d2d87b321d523cfa34d", size = 289923, upload-time = "2026-05-19T07:45:19.611Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/33/a53afeef1a56051551a0f5a801e4bce411dd73c6a8c99bad16902651256d/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9346ce6eb1fbd8b03a6b331d66016afcb4edcdff6eac708e21391600529a016a", size = 325762, upload-time = "2026-05-19T07:45:18.261Z" },
-    { url = "https://files.pythonhosted.org/packages/72/ca/4462a4f36365d7ee72d41e05e6bcfe127e861b073ab37c25b2c8a518317c/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a0fc6eb3fd821466fbab69cf356c6ec2b7327266bbbc740a2eb57c77c4bef965", size = 332359, upload-time = "2026-05-19T07:45:34.886Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/67/9d3373fa7c5a746fdecc64e30caf915c29eb632203508d87676f9243ed03/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:13a797e5e8f0dadc18351a5aa013815ddac25dce6864072a539d510910c95f71", size = 445483, upload-time = "2026-05-19T07:44:49.598Z" },
-    { url = "https://files.pythonhosted.org/packages/57/08/ce01aa6d897fc7f875844fe58cad0a542c8ebf089d9242b654b56260ecb8/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:57c3583b1f1c00a94f59726a5e2b988fa209221143919a1af5c2fc24e318fc98", size = 326281, upload-time = "2026-05-19T07:44:59.677Z" },
-    { url = "https://files.pythonhosted.org/packages/76/ef/2c719b2c26bb5b5e5061a1435c11ad2bd33ac3cd6d4cd0c7c3ac1d3396ed/uuid_utils-0.16.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:caac9c8b1d50e8fbddc76e93bfefbef472978eb45adbfdb6289d578816992953", size = 350809, upload-time = "2026-05-19T07:45:28.076Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/9b/c1ed447328b32229cca38ac4c62d309eab006e5e9c4020e2056a175bc607/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:91db59bad97ed2b9d2c6ed25082fe9762b2c422e694fe06786b28cf4e776ac4c", size = 502088, upload-time = "2026-05-19T07:44:09.208Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/e0/8442f4efe7bde72f0b4ae5f675d0c7fbe209ad0b54718b8ddf43c46c6fae/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:41985e342a30e76366a8becc60bbdb07d72cd1b86ec657b1f31654e9fb1baada", size = 607631, upload-time = "2026-05-19T07:44:19.384Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/1e/9a9fa261edf4c972f28ae83421377e3ab8dbd0bd7db58fd316e782d09a3b/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:1b0dcedf9266bf34a54d5cbe78648eaa627e02352f2a6923ed647530aea2f661", size = 567618, upload-time = "2026-05-19T07:43:58.478Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/f7/1bcfdb9d539bd42736dd6076470a42fbb5db23f79712c0a06aa0a3752f7b/uuid_utils-0.16.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:26fe23ab60f05de4ad70aaa5b6a4c2a7bbd43055e3dd6f6b31efba0532ac9c71", size = 530971, upload-time = "2026-05-19T07:45:06.348Z" },
-    { url = "https://files.pythonhosted.org/packages/24/0c/18945f417d6bb4d0dd2b7652fe36c58c4e83bcf593b9b326b83aa40b853a/uuid_utils-0.16.0-cp313-cp313t-win32.whl", hash = "sha256:7f8cf49c05d58523a0f977cb7f11afc05791a0fa164d7303b8365a34750638e7", size = 169369, upload-time = "2026-05-19T07:44:32.581Z" },
-    { url = "https://files.pythonhosted.org/packages/cc/cc/c0eb0c3fab2ed80d706369b750029143b53126809b77b36bcbb77da66bab/uuid_utils-0.16.0-cp313-cp313t-win_amd64.whl", hash = "sha256:e99f9a8b2420b228faba23a637e96efaf5c6a678b2e225870f24431c82707f50", size = 175384, upload-time = "2026-05-19T07:45:56.623Z" },
-]
-
-[[package]]
 name = "uv"
 version = "0.11.18"
 source = { registry = "https://pypi.org/simple" }
@@ -4168,15 +4068,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e1/0d/4e93c8e6d1001a75763f87d8f5ecda8ebc7f4aa2153dddfaf4ae8892821a/virtualenv-21.4.2.tar.gz", hash = "sha256:38e6ee0a555615c0ea9da2ac7e9998fe8dc3b911dd33ad8eaad2020957653b0c", size = 7613326, upload-time = "2026-05-31T17:01:22.827Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/bf/c4/557dc082be035381b85fdb2b74e21d3d21b57750b74f2b47a32f3a639ff9/virtualenv-21.4.2-py3-none-any.whl", hash = "sha256:854210ca524a1a4d0d744734f4acbc721c3ffe163b85bbf5d56d14d5ae2f0fae", size = 7594079, upload-time = "2026-05-31T17:01:20.735Z" },
-]
-
-[[package]]
-name = "vulture"
-version = "2.16"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/66/3e/4d08c5903b2c0c70cad583c170cc4a663fc6a61e2ad00b711fcda61358cd/vulture-2.16.tar.gz", hash = "sha256:f8d9f6e2af03011664a3c6c240c9765b3f392917d3135fddca6d6a68d359f717", size = 52680, upload-time = "2026-03-25T14:41:27.141Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f5/be/f935130312330614811dae2ea9df3f395f6d63889eb6c2e68c14507152ee/vulture-2.16-py3-none-any.whl", hash = "sha256:6e0f1c312cef1c87856957e5c2ca9608834a7c794c2180477f30bf0e4cc58eee", size = 26993, upload-time = "2026-03-25T14:41:26.21Z" },
 ]
 
 [[package]]
@@ -4342,57 +4233,6 @@ wheels = [
 ]
 
 [[package]]
-name = "xxhash"
-version = "3.7.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/24/2f/e183a1b407002f5af81822bee18b61cdb94b8670208ef34734d8d2b8ebe9/xxhash-3.7.0.tar.gz", hash = "sha256:6cc4eefbb542a5d6ffd6d70ea9c502957c925e800f998c5630ecc809d6702bae", size = 82022, upload-time = "2026-04-25T11:10:32.553Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c1/ca/d5174b4c36d10f64d4ca7050563138c5a599efb01a765858ddefc9c1202a/xxhash-3.7.0-cp313-cp313-android_21_arm64_v8a.whl", hash = "sha256:4b6d6b33f141158692bd4eafbb96edbc5aa0dabdb593a962db01a91983d4f8fa", size = 36813, upload-time = "2026-04-25T11:06:51.73Z" },
-    { url = "https://files.pythonhosted.org/packages/41/d0/abc6c9d347ba1f1e1e1d98125d0881a0452c7f9a76a9dd03a7b5d2197f23/xxhash-3.7.0-cp313-cp313-android_21_x86_64.whl", hash = "sha256:845d347df254d6c619f616afa921331bada8614b8d373d58725c663ba97c3605", size = 35121, upload-time = "2026-04-25T11:06:53.048Z" },
-    { url = "https://files.pythonhosted.org/packages/bf/11/4cc834eb3d79f2f2b3a6ef7324195208bcdfbdcf7534d2b17267aa5f3a8f/xxhash-3.7.0-cp313-cp313-ios_13_0_arm64_iphoneos.whl", hash = "sha256:fddbbb69a6fff4f421e7a0d1fa28f894b20112e9e3fab306af451e2dfd0e459b", size = 29624, upload-time = "2026-04-25T11:06:54.311Z" },
-    { url = "https://files.pythonhosted.org/packages/23/83/e97d3e7b635fe73a1dfb1e91f805324dd6d930bb42041cbf18f183bc0b6d/xxhash-3.7.0-cp313-cp313-ios_13_0_arm64_iphonesimulator.whl", hash = "sha256:54876a4e45101cec2bf8f31a973cda073a23e2e108538dad224ba07f85f22487", size = 30638, upload-time = "2026-04-25T11:06:55.864Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/40/d84951d80c35db1f4c40a29a64a8520eea5d56e764c603906b4fe763580f/xxhash-3.7.0-cp313-cp313-ios_13_0_x86_64_iphonesimulator.whl", hash = "sha256:0c72fe9c7e3d6dfd7f1e21e224a877917fa09c465694ba4e06464b9511b65544", size = 33323, upload-time = "2026-04-25T11:06:57.336Z" },
-    { url = "https://files.pythonhosted.org/packages/89/cc/c7dc6558d97e9ab023f663d69ab28b340ed9bf4d2d94f2c259cf896bb354/xxhash-3.7.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a6d73a830b17ef49bc04e00182bd839164c1b3c59c127cd7c54fcb10c7ed8ee8", size = 33362, upload-time = "2026-04-25T11:06:58.656Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/6e/46b84017b1301d54091430353d4ad5901654a3e0871649877a416f7f1644/xxhash-3.7.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:91c3b07cf3362086d8f126c6aecd8e5e9396ad8b2f2219ea7e49a8250c318acd", size = 30874, upload-time = "2026-04-25T11:06:59.834Z" },
-    { url = "https://files.pythonhosted.org/packages/df/5e/8f9158e3ab906ad3fec51e09b5ea0093e769f12207bfa42a368ca204e7ab/xxhash-3.7.0-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:50e879ebbac351c81565ca108db766d7832f5b8b6a5b14b8c0151f7190028e3d", size = 194185, upload-time = "2026-04-25T11:07:01.658Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/29/a804ded9f5d3d3758292678d23e7528b08fda7b7e750688d08b052322475/xxhash-3.7.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:921c14e93817842dd0dd9f372890a0f0c72e534650b6ab13c5be5cd0db11d47e", size = 213033, upload-time = "2026-04-25T11:07:03.606Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/91/1ce5a7d2fdc975267320e2c78fc1cecfe7ab735ccbcf6993ec5dd541cb2c/xxhash-3.7.0-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e64a7c9d7dfca3e0fafcbc5e455519090706a3e36e95d655cec3e04e79f95aaa", size = 236140, upload-time = "2026-04-25T11:07:05.396Z" },
-    { url = "https://files.pythonhosted.org/packages/34/04/fd595a4fd8617b05fa27bd9b684ecb4985bfed27917848eea85d54036d06/xxhash-3.7.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2220af08163baf5fa36c2b8af079dc2cbe6e66ae061385267f9472362dfd53c6", size = 212291, upload-time = "2026-04-25T11:07:06.966Z" },
-    { url = "https://files.pythonhosted.org/packages/03/fb/f1a379cbc372ae5b9f4ab36154c48a849ca6ebe3ac477067a57865bf3bc6/xxhash-3.7.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f14bb8b22a4a91325813e3d553b8963c10cf8c756cff65ee50c194431296c655", size = 445532, upload-time = "2026-04-25T11:07:08.525Z" },
-    { url = "https://files.pythonhosted.org/packages/65/59/172424b79f8cfd4b6d8a122b2193e6b8ad4b11f7159bb3b6f9b3191329bb/xxhash-3.7.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:496736f86a9bedaf64b0dc70e3539d0766df01c71ea22032698e88f3f04a1ce9", size = 193990, upload-time = "2026-04-25T11:07:10.315Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/19/aeac22161d953f139f07ba5586cb4a17c5b7b6dff985122803bb12933500/xxhash-3.7.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0ff71596bd79816975b3de7130ab1ff4541410285a3c084584eeb1c8239996fd", size = 284876, upload-time = "2026-04-25T11:07:12.15Z" },
-    { url = "https://files.pythonhosted.org/packages/77/d5/4fd0b59e7a02242953da05ff679fbb961b0a4368eac97a217e11dae110c1/xxhash-3.7.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1ad86695c19b1d46fe106925db3c7a37f16be37669dcf58dcc70a9dd6e324676", size = 210495, upload-time = "2026-04-25T11:07:13.952Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/fb/976a3165c728c7faf74aa1b5ab3cf6a85e6d731612894741840524c7d28c/xxhash-3.7.0-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:970f9f8c50961d639cbd0d988c96f80ddf66006de93641719282c4fe7a87c5e6", size = 241331, upload-time = "2026-04-25T11:07:15.557Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/2c/6763d5901d53ac9e6ba296e5717ae599025c9d268396e8faa8b4b0a8e0ac/xxhash-3.7.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:5886ad85e9e347911783760a1d16cb6b393e8f9e3b52c982568226cb56927bdc", size = 198037, upload-time = "2026-04-25T11:07:17.563Z" },
-    { url = "https://files.pythonhosted.org/packages/61/2b/876e722d533833f5f9a83473e6ba993e48745701096944e77bbecf29b2c3/xxhash-3.7.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:6e934bbae1e0ec74e27d5f0d7f37ef547ce5ff9f0a7e63fb39e559fc99526734", size = 210744, upload-time = "2026-04-25T11:07:19.055Z" },
-    { url = "https://files.pythonhosted.org/packages/21/e6/d7e7baef7ce24166b4668d3c48557bb35a23b92ecadcac7e7718d099ab69/xxhash-3.7.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:3b6b3d28228af044ebcded71c4a3dd86e1dbd7e2f4645bf40f7b5da65bb5fb5a", size = 275406, upload-time = "2026-04-25T11:07:20.908Z" },
-    { url = "https://files.pythonhosted.org/packages/92/fe/198b3763b2e01ca908f2154969a2352ec99bda892b574a11a9a151c5ede4/xxhash-3.7.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:6be4d70d9ab76c9f324ead9c01af6ff52c324745ea0c3731682a0cf99720f1fe", size = 414125, upload-time = "2026-04-25T11:07:23.037Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/6d/019a11affd5a5499137cacca53808659964785439855b5aa40dfd3412916/xxhash-3.7.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:151d7520838d4465461a0b7f4ae488b3b00de16183dd3214c1a6b14bf89d7fb6", size = 191555, upload-time = "2026-04-25T11:07:24.991Z" },
-    { url = "https://files.pythonhosted.org/packages/76/21/b96d58568df2d01533244c3e0e5cbdd0c8b2b25c4bec4d72f19259a292d7/xxhash-3.7.0-cp313-cp313-win32.whl", hash = "sha256:d798c1e291bffb8e37b5bbe0dda77fc767cd19e89cadaf66e6ed5d0ff88c9fe6", size = 30668, upload-time = "2026-04-25T11:07:26.665Z" },
-    { url = "https://files.pythonhosted.org/packages/99/57/d849a8d3afa1f8f4bc6a831cd89f49f9706fbbad94d2975d6140a171988c/xxhash-3.7.0-cp313-cp313-win_amd64.whl", hash = "sha256:875811ba23c543b1a1c3143c926e43996eb27ebb8f52d3500744aa608c275aed", size = 31524, upload-time = "2026-04-25T11:07:27.92Z" },
-    { url = "https://files.pythonhosted.org/packages/81/52/bacc753e92dee78b058af8dcef0a50815f5f860986c664a92d75f965b6a5/xxhash-3.7.0-cp313-cp313-win_arm64.whl", hash = "sha256:54a675cb300dda83d71daae2a599389d22db8021a0f8db0dd659e14626eb3ecc", size = 27768, upload-time = "2026-04-25T11:07:29.113Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/47/ddbd683b7fc7e592c1a8d9d65f73ce9ab513f082b3967eee2baf549b8fc6/xxhash-3.7.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:a3b19a42111c4057c1547a4a1396a53961dca576a0f6b82bfa88a2d1561764b2", size = 33576, upload-time = "2026-04-25T11:07:30.469Z" },
-    { url = "https://files.pythonhosted.org/packages/07/f2/36d3310161db7f72efb4562aadde0ed429f1d0531782dd6345b12d2da527/xxhash-3.7.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:8f4608a06e4d61b7a3425665a46d00e0579122e1a2fae97a0c52953a3aad9aa3", size = 31123, upload-time = "2026-04-25T11:07:31.989Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/3f/75937a5c69556ed213021e43cbedd84c8e0279d0d74e7d41a255d84ba4b1/xxhash-3.7.0-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:ad37c7792479e49cf96c1ab25517d7003fe0d93687a772ba19a097d235bbe41e", size = 196491, upload-time = "2026-04-25T11:07:33.358Z" },
-    { url = "https://files.pythonhosted.org/packages/22/29/f10d7ff8c7a733d4403a43b9de18c8fabc005f98cec054644f04418659ee/xxhash-3.7.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc026e3b89d98e30a8288c95cb696e77d150b3f0fb7a51f73dcd49ee6b5577fa", size = 215793, upload-time = "2026-04-25T11:07:34.919Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/fd/778f60aa295f58907938f030a8b514611f391405614a525cccd2ffc00eb5/xxhash-3.7.0-cp313-cp313t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:c9b31ab1f28b078a6a1ac1a54eb35e7d5390deddd56870d0be3a0a733d1c321c", size = 237993, upload-time = "2026-04-25T11:07:36.638Z" },
-    { url = "https://files.pythonhosted.org/packages/70/f5/736db5de387b4a540e37a05b84b40dc58a1ce974bfd2b4e5754ce29b68c3/xxhash-3.7.0-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:3bb5fd680c038fd5229e44e9c493782f90df9bef632fd0499d442374688ff70b", size = 214887, upload-time = "2026-04-25T11:07:38.564Z" },
-    { url = "https://files.pythonhosted.org/packages/4d/aa/09a095f22fdb9a27fbb716841fbff52119721f9ca4261952d07a912f7839/xxhash-3.7.0-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:030c0fd688fce3569fbb49a2feefd4110cbb0b650186fb4610759ecfac677548", size = 448407, upload-time = "2026-04-25T11:07:40.552Z" },
-    { url = "https://files.pythonhosted.org/packages/74/8a/b745efeeca9e34a91c26fdc97ad8514c43d5a81ac78565cba80a1353870a/xxhash-3.7.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5b1bde10324f4c31812ae0d0502e92d916ae8917cad7209353f122b8b8f610c3", size = 196119, upload-time = "2026-04-25T11:07:42.101Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/5c/0cfceb024af90c191f665c7933b1f318ee234f4797858383bebd1881d52f/xxhash-3.7.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:503722d52a615f2604f5e7611de7d43878df010dc0053094ef91cb9a9ac3d987", size = 286751, upload-time = "2026-04-25T11:07:43.568Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/0a/0793e405dc3cf8f4ebe2c1acec1e4e4608cd9e7e50ea691dabbc2a95ccbb/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c72500a3b6d6c30ebfc135035bcace9eb5884f2dc220804efcaaba43e9f611dd", size = 212961, upload-time = "2026-04-25T11:07:45.388Z" },
-    { url = "https://files.pythonhosted.org/packages/0c/7e/721118ffc63bfff94aa565bcf2555a820f9f4bdb0f001e0d609bdfad70de/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_armv7l.whl", hash = "sha256:43475925a766d01ca8cd9a857fd87f3d50406983c8506a4c07c4df12adcc867f", size = 243703, upload-time = "2026-04-25T11:07:47.053Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/18/16f6267160488b8276fd3d449d425712512add292ba545c1b6946bfdb7dd/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:8d09dfd2ab135b985daf868b594315ebe11ad86cd9fea46e6c69f19b28f7d25a", size = 200894, upload-time = "2026-04-25T11:07:48.657Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/94/80ba841287fd97e3e9cac1d228788c8ef623746f570404961eec748ecb5c/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:c50269d0055ac1faecfd559886d2cbe4b730de236585aba0e873f9d9dadbe585", size = 213357, upload-time = "2026-04-25T11:07:50.257Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/7e/106d4067130c59f1e18a55ffadcd876d8c68534883a1e02685b29d3d8153/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:1910df4756a5ab58cfad8744fc2d0f23926e3efcc346ee76e87b974abab922f4", size = 277600, upload-time = "2026-04-25T11:07:51.745Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/86/a081dd30da71d720b2612a792bfd55e45fa9a07ac76a0507f60487473c25/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:d006faf3b491957efcb433489be3c149efe4787b7063d5cddb8ddaefdc60e0c1", size = 416980, upload-time = "2026-04-25T11:07:53.504Z" },
-    { url = "https://files.pythonhosted.org/packages/35/29/1a95221a029a3c1293773869e1ab47b07cbbdd82444a42809e8c60156626/xxhash-3.7.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:abb65b4e947e958f7b3b0d71db3ce447d1bc5f37f5eab871ce7223bda8768a04", size = 193840, upload-time = "2026-04-25T11:07:55.103Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/e0/db909dd0823285de2286f67e10ee4d81e96ad35d7d8e964ecb07fccd8af9/xxhash-3.7.0-cp313-cp313t-win32.whl", hash = "sha256:178959906cb1716a1ce08e0d69c82886c70a15a6f2790fc084fdd146ca30cd49", size = 30966, upload-time = "2026-04-25T11:07:56.524Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/ff/d705b15b22f21ee106adce239cb65d35067a158c630b240270f09b17c2e6/xxhash-3.7.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2524a1e20d4c231d13b50f7cf39e44265b055669a64a7a4b9a2a44faa03f19b6", size = 31784, upload-time = "2026-04-25T11:07:57.758Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/1f/b2cf83c3638fd0588e0b17f22e5a9400bdfb1a3e3755324ac0aee2250b88/xxhash-3.7.0-cp313-cp313t-win_arm64.whl", hash = "sha256:37d994d0ffe81ef087bb330d392caa809bb5853c77e22ea3f71db024a0543dba", size = 27932, upload-time = "2026-04-25T11:07:59.109Z" },
-]
-
-[[package]]
 name = "yamlfix"
 version = "1.19.1"
 source = { registry = "https://pypi.org/simple" }
@@ -4508,29 +4348,4 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/73/ec/0959952a13124b5d58829f808daabe2d2e0358d25b33f7460366ddab21ce/zopfli-0.4.2-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:70c20595aa30aae246ac71a9fa471e2aa768318150ab814aeea2f651c59c6a32", size = 1863865, upload-time = "2026-05-26T11:00:35.297Z" },
     { url = "https://files.pythonhosted.org/packages/38/0e/11dab5379262c9b19ec9a2d8c0bc4314f62a47047ac6f54912a2e0fb82df/zopfli-0.4.2-cp310-abi3-win32.whl", hash = "sha256:d3bc0b483575ab8849d9c15b349f78ae0141eb4dfe2ba260c8fdc0b3ba5c6c42", size = 82229, upload-time = "2026-05-26T11:00:38.07Z" },
     { url = "https://files.pythonhosted.org/packages/04/f6/f75c781c1464045a3c465625e813605636f09e5fb2e15494eeee5263f8ef/zopfli-0.4.2-cp310-abi3-win_amd64.whl", hash = "sha256:bc25a3b3568910afb4bbd951d99835de29cade95417bca215339eac172eb381d", size = 102103, upload-time = "2026-05-26T11:00:36.842Z" },
-]
-
-[[package]]
-name = "zstandard"
-version = "0.25.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fd/aa/3e0508d5a5dd96529cdc5a97011299056e14c6505b678fd58938792794b1/zstandard-0.25.0.tar.gz", hash = "sha256:7713e1179d162cf5c7906da876ec2ccb9c3a9dcbdffef0cc7f70c3667a205f0b", size = 711513, upload-time = "2025-09-14T22:15:54.002Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/35/0b/8df9c4ad06af91d39e94fa96cc010a24ac4ef1378d3efab9223cc8593d40/zstandard-0.25.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:ec996f12524f88e151c339688c3897194821d7f03081ab35d31d1e12ec975e94", size = 795735, upload-time = "2025-09-14T22:17:26.042Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/06/9ae96a3e5dcfd119377ba33d4c42a7d89da1efabd5cb3e366b156c45ff4d/zstandard-0.25.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a1a4ae2dec3993a32247995bdfe367fc3266da832d82f8438c8570f989753de1", size = 640440, upload-time = "2025-09-14T22:17:27.366Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/14/933d27204c2bd404229c69f445862454dcc101cd69ef8c6068f15aaec12c/zstandard-0.25.0-cp313-cp313-manylinux2010_i686.manylinux2014_i686.manylinux_2_12_i686.manylinux_2_17_i686.whl", hash = "sha256:e96594a5537722fdfb79951672a2a63aec5ebfb823e7560586f7484819f2a08f", size = 5343070, upload-time = "2025-09-14T22:17:28.896Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/db/ddb11011826ed7db9d0e485d13df79b58586bfdec56e5c84a928a9a78c1c/zstandard-0.25.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:bfc4e20784722098822e3eee42b8e576b379ed72cca4a7cb856ae733e62192ea", size = 5063001, upload-time = "2025-09-14T22:17:31.044Z" },
-    { url = "https://files.pythonhosted.org/packages/db/00/87466ea3f99599d02a5238498b87bf84a6348290c19571051839ca943777/zstandard-0.25.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:457ed498fc58cdc12fc48f7950e02740d4f7ae9493dd4ab2168a47c93c31298e", size = 5394120, upload-time = "2025-09-14T22:17:32.711Z" },
-    { url = "https://files.pythonhosted.org/packages/2b/95/fc5531d9c618a679a20ff6c29e2b3ef1d1f4ad66c5e161ae6ff847d102a9/zstandard-0.25.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:fd7a5004eb1980d3cefe26b2685bcb0b17989901a70a1040d1ac86f1d898c551", size = 5451230, upload-time = "2025-09-14T22:17:34.41Z" },
-    { url = "https://files.pythonhosted.org/packages/63/4b/e3678b4e776db00f9f7b2fe58e547e8928ef32727d7a1ff01dea010f3f13/zstandard-0.25.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8e735494da3db08694d26480f1493ad2cf86e99bdd53e8e9771b2752a5c0246a", size = 5547173, upload-time = "2025-09-14T22:17:36.084Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/d5/ba05ed95c6b8ec30bd468dfeab20589f2cf709b5c940483e31d991f2ca58/zstandard-0.25.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:3a39c94ad7866160a4a46d772e43311a743c316942037671beb264e395bdd611", size = 5046736, upload-time = "2025-09-14T22:17:37.891Z" },
-    { url = "https://files.pythonhosted.org/packages/50/d5/870aa06b3a76c73eced65c044b92286a3c4e00554005ff51962deef28e28/zstandard-0.25.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:172de1f06947577d3a3005416977cce6168f2261284c02080e7ad0185faeced3", size = 5576368, upload-time = "2025-09-14T22:17:40.206Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/35/398dc2ffc89d304d59bc12f0fdd931b4ce455bddf7038a0a67733a25f550/zstandard-0.25.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:3c83b0188c852a47cd13ef3bf9209fb0a77fa5374958b8c53aaa699398c6bd7b", size = 4954022, upload-time = "2025-09-14T22:17:41.879Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/5c/36ba1e5507d56d2213202ec2b05e8541734af5f2ce378c5d1ceaf4d88dc4/zstandard-0.25.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:1673b7199bbe763365b81a4f3252b8e80f44c9e323fc42940dc8843bfeaf9851", size = 5267889, upload-time = "2025-09-14T22:17:43.577Z" },
-    { url = "https://files.pythonhosted.org/packages/70/e8/2ec6b6fb7358b2ec0113ae202647ca7c0e9d15b61c005ae5225ad0995df5/zstandard-0.25.0-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:0be7622c37c183406f3dbf0cba104118eb16a4ea7359eeb5752f0794882fc250", size = 5433952, upload-time = "2025-09-14T22:17:45.271Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/01/b5f4d4dbc59ef193e870495c6f1275f5b2928e01ff5a81fecb22a06e22fb/zstandard-0.25.0-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:5f5e4c2a23ca271c218ac025bd7d635597048b366d6f31f420aaeb715239fc98", size = 5814054, upload-time = "2025-09-14T22:17:47.08Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/e5/fbd822d5c6f427cf158316d012c5a12f233473c2f9c5fe5ab1ae5d21f3d8/zstandard-0.25.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4f187a0bb61b35119d1926aee039524d1f93aaf38a9916b8c4b78ac8514a0aaf", size = 5360113, upload-time = "2025-09-14T22:17:48.893Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/e0/69a553d2047f9a2c7347caa225bb3a63b6d7704ad74610cb7823baa08ed7/zstandard-0.25.0-cp313-cp313-win32.whl", hash = "sha256:7030defa83eef3e51ff26f0b7bfb229f0204b66fe18e04359ce3474ac33cbc09", size = 436936, upload-time = "2025-09-14T22:17:52.658Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/82/b9c06c870f3bd8767c201f1edbdf9e8dc34be5b0fbc5682c4f80fe948475/zstandard-0.25.0-cp313-cp313-win_amd64.whl", hash = "sha256:1f830a0dac88719af0ae43b8b2d6aef487d437036468ef3c2ea59c51f9d55fd5", size = 506232, upload-time = "2025-09-14T22:17:50.402Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/57/60c3c01243bb81d381c9916e2a6d9e149ab8627c0c7d7abb2d73384b3c0c/zstandard-0.25.0-cp313-cp313-win_arm64.whl", hash = "sha256:85304a43f4d513f5464ceb938aa02c1e78c2943b29f44a750b48b25ac999a049", size = 462671, upload-time = "2025-09-14T22:17:51.533Z" },
 ]


### PR DESCRIPTION
## Summary

Implements `docs/superpowers/specs/2026-06-07-lean-deps-and-sbom-design.md`. Two goals: reduce the dependency/upgrade chore, and produce an official, vuln-scanned CycloneDX SBOM.

**Lean dependencies**
- **Pruned:** `chromadb` (redundant pin — `crewai` hard-deps `chromadb~=1.1.0`), `langsmith` + `pendulum` (test, unused/meta-test only), `vulture` (dev tool never invoked).
- **Fixed undeclared-but-imported deps:** declared `urllib3` + `python-dateutil` (runtime, zero new resolved packages — were transitive) and `tabulate` (dev, used by `scripts/`); removed a dead `markdownify` branch in `app.py` (the bs4 fallback already covered it).
- **`deptry` guardrail** (`make deps-audit`, `[tool.deptry]` config) to catch future drift.

**Official, secured SBOM**
- **`make sbom`** → CycloneDX 1.6 from `uv.lock` (via `uv export` + pinned `cyclonedx-bom==7.3.0`, run through `uvx` for zero lockfile weight). 236 components.
- **Replaced deprecated `safety` with `osv-scanner`** (`make security`), gated by a documented `osv-scanner.toml` allowlist.
- **`.github/workflows/security.yml`:** SBOM + `deptry` + **checksum-verified** osv-scanner scan (blocking) on PR/push/weekly schedule; SBOM uploaded as artifact always and attached to GitHub Releases on `v*` tags. Least-privilege permissions.

**Tame Dependabot**
- Grouped minor/patch into single weekly PRs (majors stay individual), capped at 5 open, added a grouped `github-actions` ecosystem.

## ⚠️ Security note — one allowlisted Critical (needs awareness)

osv-scanner flags **CVE-2026-45829 / GHSA-f4j7-r4q5-qw2c (CVSS 9.3)** in `chromadb 1.1.1` — a **pre-auth RCE in ChromaDB's network *server* API**, with **no patched version** (affects 1.0.0–1.5.9). It is a **forced transitive dep of crewai** (`chromadb~=1.1.0`) and epic_news **runs no ChromaDB server and never imports it directly** (embedded-only), so the vulnerable endpoint is never exposed. Allowlisted in `osv-scanner.toml` with a documented reason and `ignoreUntil = 2026-09-07` for re-evaluation. (Risk acceptance approved.)

## Follow-ups (out of scope here)
- Replace unmaintained `newspaper3k` with `trafilatura` → would let us also drop `lxml` + `lxml-html-clean`.
- Consider adding `bandit` to CI (currently has pre-existing findings: 1 High / 17 Med / 7 Low — needs triage first).

## Test Plan
- [x] `make lint` clean
- [x] `uv run mypy src/epic_news` — no issues (222 files)
- [x] `uv run pytest -q` — 555 passed, 5 skipped
- [x] `make deps-audit` (deptry) — exit 0
- [x] `make sbom` — valid CycloneDX 1.6, 236 components
- [x] real osv-scanner v2.3.8 gate — exit 0 with allowlist (was exit 1 / 1 Critical before)
- [x] `yamllint` + `actionlint` clean on `security.yml`
- [ ] CI green (existing `CI` + new `Security & SBOM`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added SBOM generation and automated vulnerability scanning to CI pipeline
  * Enhanced security checks with dependency auditing guardrails

* **Chores**
  * Removed unnecessary dependencies for a leaner dependency tree
  * Replaced deprecated vulnerability scanner with modern alternatives
  * Updated Dependabot configuration for grouped, capped dependency updates
  * Improved HTML text extraction robustness

<!-- end of auto-generated comment: release notes by coderabbit.ai -->