### PR TITLE
ci: waive unfixable nltk advisory + drop 4 unused type:ignores

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -19,3 +19,15 @@ does not import chromadb directly (0 imports); it is a forced transitive depende
 of crewai (chromadb~=1.1.0) used only as an embedded library, so the vulnerable \
 network endpoint is never exposed. Re-evaluate when chromadb ships a fix or crewai \
 relaxes the pin."""
+
+[[IgnoredVulns]]
+id = "GHSA-p4gq-832x-fm9v"  # CVE-2026-54293 — nltk path traversal in nltk.data.load() (CVSS 7.5)
+ignoreUntil = 2026-09-07
+reason = """
+URL-encoded path traversal in nltk.data.load() via the nltk: URL scheme \
+(decode-after-check flaw) allowing arbitrary local file read. Affects ALL nltk \
+versions through 3.9.4 with NO patched version available. nltk is a forced \
+transitive dependency (pulled via crewai/langchain) — epic_news has 0 direct \
+nltk imports and never calls nltk.data.load() on attacker-controlled nltk:-scheme \
+paths, so the traversal sink is unreachable. Re-evaluate when nltk ships a fix or \
+the transitive dependency is dropped."""

--- a/src/epic_news/main.py
+++ b/src/epic_news/main.py
@@ -493,7 +493,7 @@ class ReceptionFlow(Flow[ContentState]):
             return
 
         # Store the final report path in the state (only when HTML write actually succeeded)
-        self.state.rss_weekly_report = f"Report generated at {html_report_path}"  # type: ignore[assignment]
+        self.state.rss_weekly_report = f"Report generated at {html_report_path}"
         self.state.output_file = str(html_report_path)
         self.logger.info(f"✅ New RSS weekly pipeline complete. Report at: {html_report_path}")
 
@@ -748,7 +748,7 @@ class ReceptionFlow(Flow[ContentState]):
 
         if menu_structure_result is None:
             self.logger.error("❌ No menu structure available for recipe generation")
-            self.state.menu_designer_report = final_report  # type: ignore[assignment]
+            self.state.menu_designer_report = final_report
             return
 
         recipe_specs = menu_generator.parse_menu_structure(menu_structure_result)
@@ -780,7 +780,7 @@ class ReceptionFlow(Flow[ContentState]):
             except Exception as e:
                 self.logger.error(f"  ❌ Error with {recipe_code}: {e}")
 
-        self.state.menu_designer_report = final_report  # type: ignore[assignment]
+        self.state.menu_designer_report = final_report
 
     @listen("go_generate_book_summary")
     @trace_task(tracer)
@@ -848,7 +848,7 @@ class ReceptionFlow(Flow[ContentState]):
         self.state.shopping_advice_model = shopping_advice_obj
 
         # Set output file path
-        topic = self.state.extracted_info.topic or "product-recommendation"  # type: ignore[union-attr]
+        topic = self.state.extracted_info.topic or "product-recommendation"
         topic_slug = topic.lower().replace(" ", "-").replace("'", "").replace('"', "")
         html_file = f"output/shopping_advisor/shopping-advice-{topic_slug}.html"
         self.state.output_file = html_file


### PR DESCRIPTION
The blocking OSV-Scanner step fails on GHSA-p4gq-832x-fm9v (CVE-2026-54293), a path-traversal in `nltk.data.load()` affecting all nltk versions through 3.9.4 with **no patched version available**. nltk is a forced transitive dependency (via crewai/langchain) — epic_news has 0 direct nltk imports and never calls the vulnerable sink, so it is unreachable. Adds a documented, expiring waiver (ignoreUntil 2026-09-07) to `osv-scanner.toml`, matching the existing chromadb entry. The scan stays blocking for everything else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)