### PR TITLE
fix(security): allowlist PYSEC-2026-597 (duplicate of accepted nltk CVE)

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -31,3 +31,13 @@ transitive dependency (pulled via crewai/langchain) — epic_news has 0 direct \
 nltk imports and never calls nltk.data.load() on attacker-controlled nltk:-scheme \
 paths, so the traversal sink is unreachable. Re-evaluate when nltk ships a fix or \
 the transitive dependency is dropped."""
+
+[[IgnoredVulns]]
+id = "PYSEC-2026-597"  # Same nltk vulnerability as GHSA-p4gq-832x-fm9v / CVE-2026-54293, republished by OSV under a PYSEC id not linked as an alias
+ignoreUntil = 2026-09-07
+reason = """
+Duplicate OSV record for the nltk.data.load() path traversal already accepted \
+above (GHSA-p4gq-832x-fm9v): osv-scanner only auto-filters ids listed as aliases, \
+and this PYSEC record is not cross-linked, so it must be ignored explicitly. \
+Same assessment applies: no patched nltk exists, epic_news never calls \
+nltk.data.load(), sink unreachable. Re-evaluate with the GHSA entry."""


### PR DESCRIPTION
## Summary
The blocking osv-scanner step on main fails because OSV republished the already-accepted nltk `nltk.data.load()` path-traversal (GHSA-p4gq-832x-fm9v / CVE-2026-54293, dismissed as tolerable risk — no fix exists, sink unreachable) under a new record id `PYSEC-2026-597` that is not cross-linked as an alias, so the existing allowlist entry no longer matches.

This adds an explicit allowlist entry for the PYSEC id with the same rationale and the same 2026-09-07 review date.

Failing run: https://github.com/fjacquet/epic_news/actions/runs/28710286005

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011185CinbhZYmU5XDew9hZJ