### PR TITLE
chore(release): v3.3.0 — multi-arch Docker images + version/changelog sync

### DIFF
--- a/.github/workflows/docker-publish-api.yml
+++ b/.github/workflows/docker-publish-api.yml
@@ -87,10 +87,11 @@ jobs:
       # Export the digest so the merge job can assemble the manifest list.
       - name: Export digest
         if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p "${{ runner.temp }}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-publish-api.yml
+++ b/.github/workflows/docker-publish-api.yml
@@ -15,7 +15,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # One native runner per architecture — no QEMU emulation.
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -26,6 +35,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Prepare platform pair
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
@@ -48,6 +62,80 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Extract labels for Docker (tags are applied in the merge job)
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            docker.io/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ env.IMAGE_NAME }}
+
+      # Build the single-arch image and push it by digest to both registries.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.api
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,"name=docker.io/${{ env.IMAGE_NAME }},ghcr.io/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      # Export the digest so the merge job can assemble the manifest list.
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    # Assemble the per-arch digests into a single multi-arch manifest list for
+    # every tag, on both registries. Skipped on pull requests (no push).
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Extract metadata (tags, labels) for Docker
       - name: Extract Docker metadata
         id: meta
@@ -60,19 +148,25 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch
-            type=ref,event=pr
             type=sha,format=long
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
-      # Build and push Docker image
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile.api
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Create one manifest list per registry from the per-arch digests.
+      - name: Create and push manifest list
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          METADATA_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          for registry in docker.io ghcr.io; do
+            image="${registry}/${IMAGE_NAME}"
+            tags="$(jq -cr --arg r "${registry}/" '.tags | map(select(startswith($r)) | "-t " + .) | join(" ")' <<< "$METADATA_JSON")"
+            # shellcheck disable=SC2046,SC2086
+            docker buildx imagetools create $tags \
+              $(printf "${image}@sha256:%s " *)
+          done
+
+      - name: Inspect image
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          docker buildx imagetools inspect "docker.io/${IMAGE_NAME}:${VERSION}"

--- a/.github/workflows/docker-publish-code-interpreter.yml
+++ b/.github/workflows/docker-publish-code-interpreter.yml
@@ -87,10 +87,11 @@ jobs:
       # Export the digest so the merge job can assemble the manifest list.
       - name: Export digest
         if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p "${{ runner.temp }}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-publish-code-interpreter.yml
+++ b/.github/workflows/docker-publish-code-interpreter.yml
@@ -15,7 +15,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # One native runner per architecture — no QEMU emulation.
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -26,6 +35,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Prepare platform pair
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
@@ -48,6 +62,80 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Extract labels for Docker (tags are applied in the merge job)
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            docker.io/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ env.IMAGE_NAME }}
+
+      # Build the single-arch image and push it by digest to both registries.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.streamlit
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,"name=docker.io/${{ env.IMAGE_NAME }},ghcr.io/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      # Export the digest so the merge job can assemble the manifest list.
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    # Assemble the per-arch digests into a single multi-arch manifest list for
+    # every tag, on both registries. Skipped on pull requests (no push).
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Extract metadata (tags, labels) for Docker
       - name: Extract Docker metadata
         id: meta
@@ -60,19 +148,25 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch
-            type=ref,event=pr
             type=sha,format=long
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
-      # Build and push Docker image
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile.streamlit
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Create one manifest list per registry from the per-arch digests.
+      - name: Create and push manifest list
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          METADATA_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          for registry in docker.io ghcr.io; do
+            image="${registry}/${IMAGE_NAME}"
+            tags="$(jq -cr --arg r "${registry}/" '.tags | map(select(startswith($r)) | "-t " + .) | join(" ")' <<< "$METADATA_JSON")"
+            # shellcheck disable=SC2046,SC2086
+            docker buildx imagetools create $tags \
+              $(printf "${image}@sha256:%s " *)
+          done
+
+      - name: Inspect image
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          docker buildx imagetools inspect "docker.io/${IMAGE_NAME}:${VERSION}"

--- a/.github/workflows/docker-publish-combined.yml
+++ b/.github/workflows/docker-publish-combined.yml
@@ -87,10 +87,11 @@ jobs:
       # Export the digest so the merge job can assemble the manifest list.
       - name: Export digest
         if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p "${{ runner.temp }}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-publish-combined.yml
+++ b/.github/workflows/docker-publish-combined.yml
@@ -15,7 +15,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # One native runner per architecture — no QEMU emulation.
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -26,6 +35,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Prepare platform pair
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
@@ -48,6 +62,80 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Extract labels for Docker (tags are applied in the merge job)
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            docker.io/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ env.IMAGE_NAME }}
+
+      # Build the single-arch image and push it by digest to both registries.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.combined
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,"name=docker.io/${{ env.IMAGE_NAME }},ghcr.io/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      # Export the digest so the merge job can assemble the manifest list.
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    # Assemble the per-arch digests into a single multi-arch manifest list for
+    # every tag, on both registries. Skipped on pull requests (no push).
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Extract metadata (tags, labels) for Docker
       - name: Extract Docker metadata
         id: meta
@@ -60,19 +148,25 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch
-            type=ref,event=pr
             type=sha,format=long
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
-      # Build and push Docker image
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile.combined
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Create one manifest list per registry from the per-arch digests.
+      - name: Create and push manifest list
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          METADATA_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          for registry in docker.io ghcr.io; do
+            image="${registry}/${IMAGE_NAME}"
+            tags="$(jq -cr --arg r "${registry}/" '.tags | map(select(startswith($r)) | "-t " + .) | join(" ")' <<< "$METADATA_JSON")"
+            # shellcheck disable=SC2046,SC2086
+            docker buildx imagetools create $tags \
+              $(printf "${image}@sha256:%s " *)
+          done
+
+      - name: Inspect image
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          docker buildx imagetools inspect "docker.io/${IMAGE_NAME}:${VERSION}"

--- a/.github/workflows/docker-publish-streamlit.yml
+++ b/.github/workflows/docker-publish-streamlit.yml
@@ -87,10 +87,11 @@ jobs:
       # Export the digest so the merge job can assemble the manifest list.
       - name: Export digest
         if: github.event_name != 'pull_request'
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
           mkdir -p "${{ runner.temp }}/digests"
-          digest="${{ steps.build.outputs.digest }}"
-          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+          touch "${{ runner.temp }}/digests/${DIGEST#sha256:}"
 
       - name: Upload digest
         if: github.event_name != 'pull_request'

--- a/.github/workflows/docker-publish-streamlit.yml
+++ b/.github/workflows/docker-publish-streamlit.yml
@@ -15,7 +15,16 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    # One native runner per architecture — no QEMU emulation.
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
     permissions:
       contents: read
       packages: write
@@ -26,6 +35,11 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+
+      - name: Prepare platform pair
+        run: |
+          platform="${{ matrix.platform }}"
+          echo "PLATFORM_PAIR=${platform//\//-}" >> "$GITHUB_ENV"
 
       # Set up Docker Buildx
       - name: Set up Docker Buildx
@@ -48,6 +62,80 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Extract labels for Docker (tags are applied in the merge job)
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: |
+            docker.io/${{ env.IMAGE_NAME }}
+            ghcr.io/${{ env.IMAGE_NAME }}
+
+      # Build the single-arch image and push it by digest to both registries.
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile.streamlit
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}-${{ env.PLATFORM_PAIR }}
+          outputs: type=image,"name=docker.io/${{ env.IMAGE_NAME }},ghcr.io/${{ env.IMAGE_NAME }}",push-by-digest=true,name-canonical=true,push=${{ github.event_name != 'pull_request' }}
+
+      # Export the digest so the merge job can assemble the manifest list.
+      - name: Export digest
+        if: github.event_name != 'pull_request'
+        run: |
+          mkdir -p "${{ runner.temp }}/digests"
+          digest="${{ steps.build.outputs.digest }}"
+          touch "${{ runner.temp }}/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: ${{ runner.temp }}/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  merge:
+    # Assemble the per-arch digests into a single multi-arch manifest list for
+    # every tag, on both registries. Skipped on pull requests (no push).
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    needs: [ build ]
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: ${{ runner.temp }}/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Extract metadata (tags, labels) for Docker
       - name: Extract Docker metadata
         id: meta
@@ -60,19 +148,25 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=ref,event=branch
-            type=ref,event=pr
             type=sha,format=long
             type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
 
-      # Build and push Docker image
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile.streamlit
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      # Create one manifest list per registry from the per-arch digests.
+      - name: Create and push manifest list
+        working-directory: ${{ runner.temp }}/digests
+        env:
+          METADATA_JSON: ${{ steps.meta.outputs.json }}
+        run: |
+          for registry in docker.io ghcr.io; do
+            image="${registry}/${IMAGE_NAME}"
+            tags="$(jq -cr --arg r "${registry}/" '.tags | map(select(startswith($r)) | "-t " + .) | join(" ")' <<< "$METADATA_JSON")"
+            # shellcheck disable=SC2046,SC2086
+            docker buildx imagetools create $tags \
+              $(printf "${image}@sha256:%s " *)
+          done
+
+      - name: Inspect image
+        env:
+          VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          docker buildx imagetools inspect "docker.io/${IMAGE_NAME}:${VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ A correctness-and-confidence release. Request classification and flow routing ge
 
 ### Changed
 - **Multi-arch Docker images** (`linux/amd64` + `linux/arm64`): the four image-publish workflows now build each architecture on a native runner (`ubuntu-latest` / `ubuntu-24.04-arm`, no QEMU emulation) and merge them into a single manifest list per tag, pushed to both Docker Hub and GHCR. Images now run natively on Apple Silicon instead of failing with `no matching manifest for linux/arm64/v8`.
+- **Compose pulls from GHCR**: `docker-compose.yml` and `docker-compose.combined.yml` now reference `ghcr.io/fjacquet/…` images instead of Docker Hub, and the combined compose moves off the stale `:master` tag to `:latest`.
 - **Dependencies**: updated `crewai-tools[mcp]` (#126, #128), two `python-minor-patch` groups of 9 updates each (#125, #127), and `actions/checkout` (#124); dropped unused `pytest-datadir`.
 - **Dependabot auto-merge workflow** (#123): grouped minor/patch dependency PRs auto-merge once checks pass.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,72 @@ All notable changes to Epic News are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.3.0] — 2026-07-04
+
+A correctness-and-confidence release. Request classification and flow routing get real bug fixes, every crew now builds its agents through `LLMConfig` (no more drifting or hardcoded LLM wiring), CrewAI 1.15's concurrent async tasks each receive an isolated agent copy, and the test suite is substantially hardened with deterministic end-to-end flow coverage and contract-freezing ratchet tests. No public API or breaking changes.
+
+### Fixed
+- **Flow routing cleanup** (`flow_enforcement` / `ReceptionFlow`): removed dead listeners and unroutable categories, with a new wiring contract test so orphaned routes can't silently reappear.
+- **`SHOPPING` classification**: the classifier now offers the routable `SHOPPING` category instead of the orphan `SHOPPING_ADVISOR`, so shopping requests actually reach a crew. Added word-boundary category matching in the prompt guard to stop substring false-positives.
+- **CrewAI 1.15 concurrent async isolation**: concurrent async tasks each receive their own isolated agent copy (`.copy()`), fixing shared-state contention under CrewAI 1.15.
+- **Crews routed through `LLMConfig`**: `hr_reporter` plus five other crews now build their agents via `LLMConfig` instead of hardcoded/drifting configuration; added an LLM contract test and dropped the contract `xfail`.
+- **`LLMConfig` contract sentinel** (refactor): repaired dead `field_mapping` keys and a `fin_daily` wiring gap, guarded by a contract sentinel.
+- **Loguru in `flow_enforcement`**: switched from stdlib `logging` to Loguru and repaired malformed log placeholders.
+
+### Security
+- **OSV allowlist**: allowlisted `PYSEC-2026-597`, a duplicate OSV record of the already-accepted nltk advisory (`GHSA-p4gq-832x-fm9v`).
+
+### Tests
+- Deterministic end-to-end `ReceptionFlow` tests with stubbed `kickoff`.
+- Ratchet test freezing the JSON-contract violation list; characterization of `to_crew_inputs()` with full `field_mapping` coverage.
+- Deduplicated crew registry & e2e fixtures, cached scans, added a stacked-listen guard, and replaced debug prints with logger calls.
+
+### Changed
+- **Multi-arch Docker images** (`linux/amd64` + `linux/arm64`): the four image-publish workflows now build each architecture on a native runner (`ubuntu-latest` / `ubuntu-24.04-arm`, no QEMU emulation) and merge them into a single manifest list per tag, pushed to both Docker Hub and GHCR. Images now run natively on Apple Silicon instead of failing with `no matching manifest for linux/arm64/v8`.
+- **Dependencies**: updated `crewai-tools[mcp]` (#126, #128), two `python-minor-patch` groups of 9 updates each (#125, #127), and `actions/checkout` (#124); dropped unused `pytest-datadir`.
+- **Dependabot auto-merge workflow** (#123): grouped minor/patch dependency PRs auto-merge once checks pass.
+
+## [3.2.2] — 2026-06-19
+
+### Security
+- Waived the unfixable nltk advisory (`GHSA-p4gq-832x-fm9v`) in the `osv-scanner` allowlist.
+
+### Fixed
+- Dropped 4 unused `# type: ignore` comments. (#122)
+
+## [3.2.1] — 2026-06-19
+
+### Changed
+- Maintenance release: merged Dependabot dependency and security updates — `python-multipart`, `cryptography`, `starlette`, `aiohttp`, a `python-minor-patch` group of 8, and a `github-actions` group of 2. (#115, #117–#121)
+
+## [3.2.0] — 2026-06-07
+
+Official secured SBOM and a leaner dependency set. No runtime API change.
+
+### Added
+- **Official secured SBOM**: `make sbom` generates a CycloneDX 1.6 SBOM from `uv.lock` (via `uv export` + pinned `cyclonedx-bom==7.3.0`). New `.github/workflows/security.yml` generates the SBOM, runs `deptry`, and scans with a checksum-verified `osv-scanner` v2.3.8 (blocking, allowlist-gated) on PR/push/weekly; the SBOM is attached to the release.
+- **`deptry` dependency guardrail** (`make deps-audit`) to catch dependency drift.
+
+### Changed
+- Replaced the deprecated `safety` with `osv-scanner`; allowlist documented in `osv-scanner.toml`.
+- Leaner dependencies: pruned the `chromadb` direct pin, `langsmith`, `pendulum`, and `vulture`; declared previously-undeclared-but-imported `urllib3`, `python-dateutil`, and `tabulate`.
+- Dependabot now groups minor/patch updates into single weekly PRs (majors stay individual) and covers the `github-actions` ecosystem. (#114)
+
+### Security
+- Accepted risk: `chromadb` carries an unfixable upstream Critical (GHSA-f4j7-r4q5-qw2c), allowlisted in `osv-scanner.toml` — embedded use only, the vulnerable server endpoint is never exposed. Re-evaluate by 2026-09-07.
+
+## [3.1.2] — 2026-05-03
+
+Patch release restoring `make all` and clearing mypy noise after dependency bumps.
+
+### Fixed
+- **`make all` provisions a real dev environment**: the target now depends on `dev` (`--all-extras`) instead of production-only `install`, fixing ~90 `ModuleNotFoundError` collection failures caused by a stray Python 3.12 runtime.
+- **Removed 17 obsolete `# type: ignore` directives** after `beautifulsoup4 4.14.x` shipped its own type stubs; fixed a real type error in `rss_weekly_renderer.py`.
+- **Resurrected `rss_weekly_converter.py`**: corrected the import path (`epic_news.models.crews.rss_weekly_report`) and added test coverage. (#91)
+
+### Compatibility
+- No public API or behavior changes; renderer HTML output is unchanged.
+
 ## [3.1.1] — 2026-05-03
 
 ### Fixed

--- a/docker-compose.combined.yml
+++ b/docker-compose.combined.yml
@@ -1,6 +1,6 @@
 services:
   epic-news-combined:
-    image: fjacquet/epic-news-combined:master
+    image: ghcr.io/fjacquet/epic-news-combined:latest
     container_name: epic-news-combined
     restart: unless-stopped
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   api:
-    image: fjacquet/epic-news-api:latest
+    image: ghcr.io/fjacquet/epic-news-api:latest
     container_name: epic-news-api
     restart: unless-stopped
     ports:
@@ -23,7 +23,7 @@ services:
       start_period: 10s
 
   streamlit:
-    image: fjacquet/epic-news-streamlit:latest
+    image: ghcr.io/fjacquet/epic-news-streamlit:latest
     container_name: epic-news-streamlit
     restart: unless-stopped
     ports:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "epic_news"
-version = "3.2.0"
+version = "3.3.0"
 description = "epic-news using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.13,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -931,7 +931,7 @@ wheels = [
 
 [[package]]
 name = "epic-news"
-version = "3.2.0"
+version = "3.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },
@@ -3584,8 +3584,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Release v3.3.0

Cuts **v3.3.0** (minor; last release was v3.2.2) and fixes the amd64-only Docker images that broke `docker compose up` on Apple Silicon.

### Version & changelog hygiene
- Bump `pyproject.toml` **3.2.0 → 3.3.0** (+ matching `uv.lock`; the stale lock version was silently churning on every `uv run`).
- Backfill `CHANGELOG.md` — it had drifted at 3.1.1; added the new **[3.3.0]** entry plus **[3.2.2] / [3.2.1] / [3.2.0] / [3.1.2]** reconstructed from their GitHub releases, so the changelog is continuous again.

### Multi-arch Docker images (the headline fix)
The four image-publish workflows (`combined`, `api`, `streamlit`, `code-interpreter`) previously built **amd64 only** (no `platforms:`), so `ghcr.io`/Docker Hub images had no `linux/arm64` manifest and failed on Apple Silicon with `no matching manifest for linux/arm64/v8`.

Each workflow is reworked into the **native-runner** multi-arch pattern (no QEMU emulation — chosen because the compiled deps like `chromadb`/`numpy`/`pydantic-core` make emulated builds slow/flaky):
- `build` job: matrix of `linux/amd64` on `ubuntu-latest` and `linux/arm64` on `ubuntu-24.04-arm`, each pushing **by digest** to both registries.
- `merge` job: assembles the per-arch digests into one manifest list per tag for both Docker Hub and GHCR (skipped on PRs).
- On **PRs**, both arches build with `push=false` — so this PR's own checks validate the arm64 build compiles natively before merge.

### Validation
- `actionlint` — clean (exit 0). `yamllint -s` — clean.
- Pre-commit passed on commit.

### Notes / out of scope (flagged, not changed)
- `docker-publish-code-interpreter.yml` still builds from `Dockerfile.streamlit` — a pre-existing quirk, left as-is.
- The local semgrep hook flags `@vN` actions as not SHA-pinned — that's the repo's existing Dependabot-managed convention across all workflows; converting to SHA pins is a separate hardening pass.

### After merge
Tag `v3.3.0` on the merge commit → the tag push triggers the (now multi-arch) publishes → GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker images are now published as multi-architecture builds, improving support for both amd64 and arm64 platforms.
* **Bug Fixes**
  * Image publishing was updated to use per-platform builds and manifest lists, making releases more reliable across registries.
* **Chores**
  * Bumped the project version to 3.3.0 and updated the changelog for the new release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->