### PR TITLE
fix(docker): v3.3.1 — python3.13 base fixes non-root crash-loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to Epic News are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.3.1] — 2026-07-04
+
+### Fixed
+- **api/streamlit Docker images crash-looped as non-root**: the Dockerfiles used a Python **3.11** base while the project requires **3.13**, so `uv` installed a managed 3.13 interpreter under `/root/.local`. The venv's `python3` symlinked into `/root` (mode `0700`), which the non-root `myuser` runtime user couldn't traverse — every start failed with `failed to canonicalize path '/app/.venv/bin/python3': Permission denied` and the container restart-looped. (`combined` was unaffected; it runs as root.) Fixed by switching all three image Dockerfiles to `ghcr.io/astral-sh/uv:python3.13-bookworm-slim`, so the venv uses the world-readable system interpreter at `/usr/local`, which also drops the redundant second interpreter from the image.
+
 ## [3.3.0] — 2026-07-04
 
 A correctness-and-confidence release. Request classification and flow routing get real bug fixes, every crew now builds its agents through `LLMConfig` (no more drifting or hardcoded LLM wiring), CrewAI 1.15's concurrent async tasks each receive an isolated agent copy, and the test suite is substantially hardened with deterministic end-to-end flow coverage and contract-freezing ratchet tests. No public API or breaking changes.

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,5 +1,9 @@
-# 1. Use the official uv image for Python 3.11
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+# 1. Use the official uv image for Python 3.13 — MUST match requires-python.
+#    With a mismatched base (e.g. 3.11), uv installs a managed 3.13 under
+#    /root/.local, which the non-root runtime user cannot traverse -> the
+#    venv's python3 symlink fails with "Permission denied". Matching the base
+#    also avoids shipping two interpreters (smaller image).
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 # 2. Set environment variables for Python
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/Dockerfile.combined
+++ b/Dockerfile.combined
@@ -1,5 +1,8 @@
-# 1. Use the official uv image for Python 3.11
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+# 1. Use the official uv image for Python 3.13 — MUST match requires-python.
+#    With a mismatched base (e.g. 3.11), uv installs a managed 3.13 under
+#    /root/.local; matching the base avoids shipping two interpreters and the
+#    non-root permission trap in the api/streamlit images.
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 # 2. Set environment variables for Python
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/Dockerfile.streamlit
+++ b/Dockerfile.streamlit
@@ -1,5 +1,9 @@
-# 1. Use the official uv image for Python 3.11
-FROM ghcr.io/astral-sh/uv:python3.11-bookworm-slim
+# 1. Use the official uv image for Python 3.13 — MUST match requires-python.
+#    With a mismatched base (e.g. 3.11), uv installs a managed 3.13 under
+#    /root/.local, which the non-root runtime user cannot traverse -> the
+#    venv's python3 symlink fails with "Permission denied". Matching the base
+#    also avoids shipping two interpreters (smaller image).
+FROM ghcr.io/astral-sh/uv:python3.13-bookworm-slim
 
 # 2. Set environment variables for Python
 ENV PYTHONDONTWRITEBYTECODE=1 \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "epic_news"
-version = "3.3.0"
+version = "3.3.1"
 description = "epic-news using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.13,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -931,7 +931,7 @@ wheels = [
 
 [[package]]
 name = "epic-news"
-version = "3.3.0"
+version = "3.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## v3.3.1 — hotfix for v3.3.0 Docker images

The `api` and `streamlit` images published in v3.3.0 crash-loop on startup:

```
error: Failed to query Python interpreter
  Caused by: failed to canonicalize path `/app/.venv/bin/python3`: Permission denied (os error 13)
```

### Root cause (verified against the pulled image)
The Dockerfiles use a **Python 3.11** base (`uv:python3.11-bookworm-slim`) while the project requires **3.13**. So `uv sync` installs a **managed 3.13 interpreter under `/root/.local`**, and the venv's `python3` symlinks there:

```
/app/.venv/bin/python3 -> /root/.local/share/uv/python/cpython-3.13.12-.../bin/python3.13
pyvenv.cfg: home = /root/.local/share/uv/python/...
/root  drwx------  (root only)
```

The containers run as non-root **`myuser`**, which can't traverse `/root` → `Permission denied` at every start. (`combined` runs as root, so it survived — masking the bug. It was latent on amd64 too; it only surfaced now that the multi-arch images could actually be pulled and run.)

### Fix
Switch all three image Dockerfiles to **`ghcr.io/astral-sh/uv:python3.13-bookworm-slim`** — the venv then uses the world-readable system interpreter at `/usr/local/bin/python3.13`, and no second interpreter is downloaded.

### Verification
Built the api image locally (native arm64) and ran it as the default user:
```
whoami: myuser (1000)
python3 resolves to: /usr/local/bin/python3.13
RUN OK, python 3.13.11
```

### Not included (follow-up)
Image size (~3 GB) is unchanged — real slimming (multi-stage build, don't bake the `uv` cache, revisit `streamlit`'s `--all-extras`) is a separate optimization, out of scope for this hotfix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)