### PR TITLE
fix: DEEPRESEARCH routing, email recipient hardening, news_daily Markdown rendering

### DIFF
--- a/src/epic_news/crews/classify/config/tasks.yaml
+++ b/src/epic_news/crews/classify/config/tasks.yaml
@@ -15,10 +15,16 @@ classification_task:
     recommendations, buying guides, or consumer advice requests
     - FINDAILY: For financial advice, investment recommendations, portfolio analysis,
     stock market insights, crypto analysis, financial planning, daily financial reports
-    - NEWSDAILY: For daily news summaries, current events, news analysis, breaking
-    news
+    - NEWSDAILY: For GENERAL daily news digests spanning many topics — world and
+    current events, breaking news, the day's headlines. NOT for research about one
+    specific subject, technology, product, or software framework (use DEEPRESEARCH).
     - COMPANY_NEWS: For company-specific news, corporate updates, business intelligence
     about specific companies or organizations
+    - DEEPRESEARCH: For in-depth research on ONE specific subject — a technology,
+    software framework, library, SDK, programming language, scientific concept,
+    method, or the question "what's new / latest developments / state of the art
+    in X". Prefer this over NEWSDAILY whenever the request targets a specific topic
+    rather than general current events.
     - HOLIDAY_PLANNER: For vacation planning, travel itineraries, destination research
     - BOOK_SUMMARY: For book summaries, reading recommendations, literary analysis,
     book reviews, author information, literature queries, book analysis, tell me about
@@ -46,6 +52,10 @@ classification_task:
     - "company news", "corporate news", "news for company", "enterprise news", "business
     updates", "company updates"
     → COMPANY_NEWS
+    - "nouveautés d'un framework/langage/librairie", "framework", "librairie", "SDK",
+    "latest features", "developments in", "state of the art", "deep dive",
+    "veille technologique", "recherche approfondie", "crewai", "python framework"
+    → DEEPRESEARCH
     - "book", "livre", "roman", "auteur", "author", "tell me about",  → BOOK_SUMMARY
     - "saint", "saint du jour", "daily saint", "saint daily"
     → SAINT

--- a/src/epic_news/main.py
+++ b/src/epic_news/main.py
@@ -569,6 +569,9 @@ class ReceptionFlow(Flow[ContentState]):
         html_path = render_and_write_html(
             "NEWSDAILY", news_daily_model, "output/news_daily/final_report.html"
         )
+        # Point output_file at the rendered HTML (was the intermediate JSON) so the
+        # email attaches — and the UI displays — the report, not raw JSON.
+        self.state.output_file = str(html_path)
         self.state.news_daily_model = news_daily_model
         self.logger.info(f"✅ News content generated and HTML written to {html_path}")
 

--- a/src/epic_news/models/content_state.py
+++ b/src/epic_news/models/content_state.py
@@ -68,7 +68,9 @@ class CrewCategories:
 
 
 # Default values
-DEFAULT_EMAIL = os.getenv("MAIL", "fred.jacquet@gmail.com")
+# `or` (not getenv's default) so a set-but-empty MAIL ("MAIL=") still falls back
+# to a valid address instead of an empty string that breaks the email send.
+DEFAULT_EMAIL = os.getenv("MAIL") or "fred.jacquet@gmail.com"
 DEFAULT_PARTICIPANTS = [
     "John Doe <john.doe@pictet.com> - CEO",
     "Jane Smith <jane.smith@pictet.com> - CTO",

--- a/src/epic_news/models/content_state.py
+++ b/src/epic_news/models/content_state.py
@@ -68,9 +68,13 @@ class CrewCategories:
 
 
 # Default values
+# Hard-coded last-resort recipient: the default when MAIL is unset, and (via
+# report_utils) the guaranteed-valid fallback when a set MAIL is malformed.
+# Single source of truth for the literal so the two use sites can't drift.
+FALLBACK_EMAIL = "fred.jacquet@gmail.com"
 # `or` (not getenv's default) so a set-but-empty MAIL ("MAIL=") still falls back
 # to a valid address instead of an empty string that breaks the email send.
-DEFAULT_EMAIL = os.getenv("MAIL") or "fred.jacquet@gmail.com"
+DEFAULT_EMAIL = os.getenv("MAIL") or FALLBACK_EMAIL
 DEFAULT_PARTICIPANTS = [
     "John Doe <john.doe@pictet.com> - CEO",
     "Jane Smith <jane.smith@pictet.com> - CTO",

--- a/src/epic_news/utils/html/template_renderers/news_daily_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/news_daily_renderer.py
@@ -64,9 +64,9 @@ class NewsDailyRenderer(BaseRenderer):
 
             summary_content = soup.new_tag("div")
             summary_content.attrs["class"] = ["summary-content"]  # type: ignore[assignment]
-            summary_p = soup.new_tag("p")
-            summary_p.string = summary
-            summary_content.append(summary_p)
+            # Crew fills this free-text field with Markdown (bold, lists, tables) —
+            # render it to HTML instead of dumping literal **/##/| markup.
+            self.render_markdown_block(summary_content, summary)
             summary_div.append(summary_content)
             header_div.append(summary_div)
 
@@ -162,9 +162,7 @@ class NewsDailyRenderer(BaseRenderer):
         if summary:
             summary_div = soup.new_tag("div")
             summary_div.attrs["class"] = ["news-summary"]  # type: ignore[assignment]
-            summary_p = soup.new_tag("p")
-            summary_p.string = summary
-            summary_div.append(summary_p)
+            self.render_markdown_block(summary_div, summary)
             article_div.append(summary_div)
 
         parent.append(article_div)
@@ -184,10 +182,7 @@ class NewsDailyRenderer(BaseRenderer):
 
         content_div = soup.new_tag("div")
         content_div.attrs["class"] = ["methodology-content"]  # type: ignore[assignment]
-        content_p = soup.new_tag("p")
-        content_p.string = methodology
-        content_div.append(content_p)
+        self.render_markdown_block(content_div, methodology)
         method_div.append(content_div)
 
         container.append(method_div)
-

--- a/src/epic_news/utils/report_utils.py
+++ b/src/epic_news/utils/report_utils.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 from typing import Any
 
 from loguru import logger
@@ -15,9 +16,7 @@ from epic_news.utils.directory_utils import ensure_output_directory
 from epic_news.utils.html.template_manager import TemplateManager
 
 
-def _transform_rss_feeds_to_report(
-    rss_feeds_model: RssFeeds, report_title: str
-) -> RssWeeklyReport:
+def _transform_rss_feeds_to_report(rss_feeds_model: RssFeeds, report_title: str) -> RssWeeklyReport:
     """Convert a low-level RssFeeds payload into the RssWeeklyReport renderer model."""
     report_feeds = []
     for feed_data in rss_feeds_model.rss_feeds:
@@ -93,6 +92,20 @@ def generate_rss_weekly_html_report(
     logger.info("✅ HTML report successfully generated at: {}", output_html_path)
 
 
+# Guaranteed-valid final fallback so a missing/empty/typo'd MAIL env var never
+# hard-fails the send with a confusing "invalid recipient" from the email tool.
+_FALLBACK_RECIPIENT = "fred.jacquet@gmail.com"
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _valid_email(value: Any) -> str | None:
+    """Return the trimmed address if it looks like a valid email, else None."""
+    if not isinstance(value, str):
+        return None
+    value = value.strip()
+    return value if _EMAIL_RE.match(value) else None
+
+
 def prepare_email_params(state: Any) -> dict[str, Any]:
     """
     Prepares the parameters for sending an email based on the application state.
@@ -105,7 +118,20 @@ def prepare_email_params(state: Any) -> dict[str, Any]:
         A dictionary with email parameters including recipient,
         subject, body, and attachment path.
     """
-    recipient = getattr(state, "sendto", "test-ia@fjaquet.fr")
+    # The recipient is driven entirely by the MAIL env var (ContentState.sendto
+    # defaults to DEFAULT_EMAIL = os.getenv("MAIL") or ...). A getattr default is
+    # dead code because the field always exists, so a missing/empty/malformed MAIL
+    # would otherwise reach the email tool and fail with a confusing "invalid
+    # recipient". Validate and fall back to a known-good address instead.
+    recipient = _valid_email(getattr(state, "sendto", None))
+    if recipient is None:
+        logger.warning(
+            "✉️  Email recipient from state.sendto/MAIL is missing or malformed "
+            "({!r}); falling back to {}. Set a valid MAIL env var to control it.",
+            getattr(state, "sendto", None),
+            _FALLBACK_RECIPIENT,
+        )
+        recipient = _FALLBACK_RECIPIENT
     subject = f"Epic News Report: {state.selected_crew} - {state.user_request}"
     body = f"Please find the report for '{state.user_request}' attached."
     attachment_path = getattr(state, "output_file", None)

--- a/src/epic_news/utils/report_utils.py
+++ b/src/epic_news/utils/report_utils.py
@@ -6,6 +6,7 @@ from typing import Any
 from loguru import logger
 from pydantic import ValidationError
 
+from epic_news.models.content_state import FALLBACK_EMAIL
 from epic_news.models.crews.rss_weekly_report import (
     ArticleSummary,
     FeedDigest,
@@ -93,8 +94,11 @@ def generate_rss_weekly_html_report(
 
 
 # Guaranteed-valid final fallback so a missing/empty/typo'd MAIL env var never
-# hard-fails the send with a confusing "invalid recipient" from the email tool.
-_FALLBACK_RECIPIENT = "fred.jacquet@gmail.com"
+# hard-fails the send with a confusing "invalid recipient". Shares the single
+# literal with content_state (no drift) but stays independent of MAIL: a malformed
+# non-empty MAIL taints DEFAULT_EMAIL, so the fallback must be the bare constant,
+# not DEFAULT_EMAIL.
+_FALLBACK_RECIPIENT = FALLBACK_EMAIL
 _EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 
@@ -123,13 +127,16 @@ def prepare_email_params(state: Any) -> dict[str, Any]:
     # dead code because the field always exists, so a missing/empty/malformed MAIL
     # would otherwise reach the email tool and fail with a confusing "invalid
     # recipient". Validate and fall back to a known-good address instead.
-    recipient = _valid_email(getattr(state, "sendto", None))
+    raw_sendto = getattr(state, "sendto", None)
+    recipient = _valid_email(raw_sendto)
     if recipient is None:
+        # Log only the failure category, never the raw value — an invalid recipient
+        # can be user-supplied and would otherwise persist an email address (PII).
+        reason = "empty" if not (isinstance(raw_sendto, str) and raw_sendto.strip()) else "malformed"
         logger.warning(
-            "✉️  Email recipient from state.sendto/MAIL is missing or malformed "
-            "({!r}); falling back to {}. Set a valid MAIL env var to control it.",
-            getattr(state, "sendto", None),
-            _FALLBACK_RECIPIENT,
+            "✉️  Email recipient from state.sendto/MAIL is {} (value not logged); "
+            "using fallback. Set a valid MAIL env var to control it.",
+            reason,
         )
         recipient = _FALLBACK_RECIPIENT
     subject = f"Epic News Report: {state.selected_crew} - {state.user_request}"

--- a/tests/crews/test_classify_config.py
+++ b/tests/crews/test_classify_config.py
@@ -40,6 +40,16 @@ def test_classify_prompt_mentions_pestel_triggers(classify_tasks: dict) -> None:
         assert token in description, f"PESTEL trigger '{token}' missing from prompt"
 
 
+def test_classify_prompt_mentions_deepresearch_guidance(classify_tasks: dict) -> None:
+    """Regression guard: topic/tech research ("what's new in framework X") must be
+    routable to DEEPRESEARCH rather than swallowed by NEWSDAILY's news keywords."""
+    description = classify_tasks["classification_task"]["description"]
+    assert "DEEPRESEARCH" in description, "DEEPRESEARCH routing guidance missing from prompt"
+    lowered = description.lower()
+    for token in ("framework", "state of the art"):
+        assert token in lowered, f"DEEPRESEARCH trigger '{token}' missing from prompt"
+
+
 def test_classify_prompt_references_core_categories(classify_tasks: dict) -> None:
     """Each category we route on must be discoverable in the prompt — at minimum
     the high-traffic ones. Missing categories cause silent misrouting."""

--- a/tests/flows/test_generate_output_file.py
+++ b/tests/flows/test_generate_output_file.py
@@ -23,6 +23,7 @@ CASES = [
     ("generate_meeting_prep", "output/meeting/meeting_preparation.html"),
     ("generate_book_summary", "output/library/book_summary.html"),
     ("generate_holiday_plan", "output/holiday/itinerary.html"),
+    ("generate_news_daily", "output/news_daily/final_report.html"),
 ]
 
 

--- a/tests/rendering/test_template_manager_rendering/test_template_manager_rendering_snapshots_NEWSDAILY_build_newsdaily_.html
+++ b/tests/rendering/test_template_manager_rendering/test_template_manager_rendering_snapshots_NEWSDAILY_build_newsdaily_.html
@@ -1911,7 +1911,9 @@ a:hover { text-decoration: underline; }
     </div>
     
 
-    <div class="news-daily-report"><div class="news-header"><h1>📰 Actualités du Jour</h1><div class="executive-summary"><h2>📋 Résumé Exécutif</h2><div class="summary-content"><p>Points clés du jour.</p></div></div></div><section class="news-section"><h2 class="section-title">🇫🇷 France</h2><article class="news-item"><h3 class="news-title">Réforme adoptée</h3><div class="news-meta"><span class="news-date">📅 2025-08-10</span><span class="news-source">📰 Le Monde</span><a class="news-link" href="https://example.com/article" rel="noopener" target="_blank">🔗 Lire l'article</a></div><div class="news-summary"><p>Description brève de l'article</p></div></article></section></div>
+    <div class="news-daily-report"><div class="news-header"><h1>📰 Actualités du Jour</h1><div class="executive-summary"><h2>📋 Résumé Exécutif</h2><div class="summary-content"><p>Points clés du jour.</p>
+</div></div></div><section class="news-section"><h2 class="section-title">🇫🇷 France</h2><article class="news-item"><h3 class="news-title">Réforme adoptée</h3><div class="news-meta"><span class="news-date">📅 2025-08-10</span><span class="news-source">📰 Le Monde</span><a class="news-link" href="https://example.com/article" rel="noopener" target="_blank">🔗 Lire l'article</a></div><div class="news-summary"><p>Description brève de l'article</p>
+</div></article></section></div>
 
     <div class="footer">
       <p>Ce rapport a été généré automatiquement par Epic News.</p>

--- a/tests/utils/html/test_daily_news_html.py
+++ b/tests/utils/html/test_daily_news_html.py
@@ -27,6 +27,19 @@ def test_daily_news_to_html(sample_news_daily_data, tmp_path):
     assert "Test article in Suisse Romande" in html_content
 
 
+def test_daily_news_summary_renders_markdown_as_html():
+    """Regression: free-text fields render Markdown to HTML, not literal markup.
+
+    Crews emit Markdown (bold, lists, tables) in ``summary``/``resume``; the
+    renderer previously inserted it via ``tag.string`` so ``**x**`` showed raw.
+    """
+    data = NewsDailyReport(summary="Un point **capital** ici.").model_dump()
+    html = TemplateManager().render_report("NEWSDAILY", data)
+
+    assert "<strong>capital</strong>" in html
+    assert "**capital**" not in html
+
+
 @pytest.mark.skip(reason="Renderer is abstract class and can't be instantiated directly")
 def test_news_daily_renderer(sample_news_daily_data):
     """Test the NewsDailyRenderer directly."""

--- a/tests/utils/test_report_utils.py
+++ b/tests/utils/test_report_utils.py
@@ -6,6 +6,7 @@ import pytest
 from faker import Faker
 
 from epic_news.utils.report_utils import (
+    _FALLBACK_RECIPIENT,
     prepare_email_params,
     setup_crew_output_directory,
 )
@@ -28,10 +29,10 @@ def mock_state():
 
 def test_prepare_email_params_defaults(mocker, mock_state):
     """Test prepare_email_params with minimal state."""
-    # Test with default recipient (when sendto is not set)
+    # When sendto is absent, fall back to the known-good recipient (not a crash).
     params = prepare_email_params(mock_state)
 
-    assert params["recipient_email"] == "test-ia@fjaquet.fr"
+    assert params["recipient_email"] == _FALLBACK_RECIPIENT
     assert params["subject"] == f"Epic News Report: {mock_state.selected_crew} - {mock_state.user_request}"
     assert params["body"] == f"Please find the report for '{mock_state.user_request}' attached."
     assert params["attachment_path"] == mock_state.output_file
@@ -43,6 +44,24 @@ def test_prepare_email_params_defaults(mocker, mock_state):
     mock_state.sendto = test_email
     params = prepare_email_params(mock_state)
     assert params["recipient_email"] == test_email
+
+
+@pytest.mark.parametrize(
+    "bad_sendto",
+    ["", "   ", "not-an-email", "@no-local.com", "no-at-sign", "missing@tld", "a b@c.com"],
+)
+def test_prepare_email_params_invalid_recipient_falls_back(mock_state, bad_sendto):
+    """A missing/empty/malformed MAIL must fall back, not reach the email tool."""
+    mock_state.sendto = bad_sendto
+    params = prepare_email_params(mock_state)
+    assert params["recipient_email"] == _FALLBACK_RECIPIENT
+
+
+def test_prepare_email_params_trims_valid_recipient(mock_state):
+    """A valid but whitespace-padded address is accepted and trimmed."""
+    mock_state.sendto = "  user@example.com  "
+    params = prepare_email_params(mock_state)
+    assert params["recipient_email"] == "user@example.com"
 
 
 def test_setup_crew_output_directory_exists(mocker):


### PR DESCRIPTION
Three gaps surfaced from one NEWSDAILY run of *"quelles sont les nouveautés du framework python crewai en 2026"*.

## 1. Classification gap → DEEPRESEARCH
The classifier prompt detailed ~10 categories but left **DEEPRESEARCH** under `- And so on…` with zero guidance, while NEWSDAILY explicitly claimed `"information"` / `"actualités"`. So a topic/tech research request fell into NEWSDAILY (general news).
- Added a DEEPRESEARCH distinction + triggers (`framework`, `librairie`, `SDK`, `state of the art`, `veille technologique`, …) and narrowed NEWSDAILY to **general/world** news.
- Routable token verified as `DEEPRESEARCH` (→ `go_generate_deep_research`).

## 2. Email recipient hard-fail
`sendto` is **never assigned anywhere** — it's purely `sendto: str = DEFAULT_EMAIL`, and `DEFAULT_EMAIL = os.getenv("MAIL", …)`. `getenv`'s default only guards a *missing* key (not `MAIL=`), and `prepare_email_params`' `getattr` default was dead code — so an empty/malformed `MAIL` reached the email tool and hard-failed with *"Missing or invalid email recipient."*
- `DEFAULT_EMAIL` now uses `or` (guards set-but-empty).
- `prepare_email_params` validates the address and falls back to a known-good one with a clear warning.

## 3. news_daily Markdown + output_file
- The renderer inserted `summary` / `resume` / `methodology` via `tag.string`, so crew Markdown rendered as literal `**` / `##` / `|`. Now routed through `render_markdown_block` (XSS-safe, GFM tables) — same fix family as the 3.3.2 book_summary one.
- `generate_news_daily` left `output_file` pointing at the intermediate **JSON** (never repointed to the HTML) — the missed 8th case of the 3.3.2 output_file bug. This is why the email attached `news_data.json`. Now set to the rendered HTML.

## Tests
- DEEPRESEARCH prompt guard
- recipient validation/fallback (empty, whitespace, malformed) + trim-valid
- news_daily Markdown-as-HTML
- news_daily `output_file` wiring (added to the parametrized guard)
- NEWSDAILY snapshot regenerated — content byte-identical, only markdown-it's trailing `\n` differs

Full suite: 632 passed, 5 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved news classification so topic-specific research requests are routed more accurately, alongside broader daily news and company news.
  * News daily reports now render rich text formatting in summaries and methodology sections for easier reading.

* **Bug Fixes**
  * Fixed daily news report attachments so emails use the final HTML report instead of an intermediate file.
  * Improved email delivery reliability by falling back to a valid recipient when the configured address is missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->