### PR TITLE
fix(holiday_planner): async→sync to stop tool-call leaking into TaskOutput.raw

### DIFF
--- a/src/epic_news/crews/holiday_planner/holiday_planner_crew.py
+++ b/src/epic_news/crews/holiday_planner/holiday_planner_crew.py
@@ -80,11 +80,16 @@ class HolidayPlannerCrew:
 
     @task
     def research_destination(self) -> Task:
-        return Task(config=self.tasks_config["research_destination"], async_execution=True)  # type: ignore[call-arg, arg-type, index]
+        # Sequential (async_execution=False): CrewAI 1.15's concurrent async task
+        # path can leak a tool-call into TaskOutput.raw (which must be a str),
+        # crashing the crew ("Input should be a valid string ... ChatCompletion
+        # MessageToolCall"). Running these sequentially avoids the concurrency and
+        # actually improves data flow (accommodation now sees the research output).
+        return Task(config=self.tasks_config["research_destination"], async_execution=False)  # type: ignore[call-arg, arg-type, index]
 
     @task
     def recommend_accommodation_and_dining(self) -> Task:
-        return Task(config=self.tasks_config["recommend_accommodation_and_dining"], async_execution=True)  # type: ignore[call-arg, arg-type, index]
+        return Task(config=self.tasks_config["recommend_accommodation_and_dining"], async_execution=False)  # type: ignore[call-arg, arg-type, index]
 
     @task
     def plan_itinerary(self) -> Task:


### PR DESCRIPTION
Fixes the runtime crash you hit in streamlit:
```
ValidationError: 1 validation error for TaskOutput
raw: Input should be a valid string [input_value=[ChatCompletionMessageToolCall(...)]]
```

**Root cause:** `research_destination` and `recommend_accommodation_and_dining` ran with `async_execution=True` (concurrently). CrewAI 1.15's concurrent async-task path can leak a tool-calling agent's **final tool-call** into `TaskOutput.raw` (which must be a `str`) instead of driving the tool loop to a text answer. `is_litellm=True` is already set in `LLMConfig`, so this is **not** the strict-schema 400 issue — it's the async concurrency mishandling the output.

**Fix:** `async_execution=False` on both tasks. Data flow is preserved (both still finish before `plan_itinerary`) and arguably improved — accommodation now runs after research and can use its output. Slightly slower; no logic change.

**Verification:** crew constructs with all 5 tasks sequential; 21 holiday structure tests + full suite (836 passed) green. ⚠️ The crash only reproduces through a live LLM tool-call, so please confirm by re-running the holiday planner in streamlit once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)