### PR TITLE
fix(shopping): CodeRabbit follow-ups from #139 (XSS scheme, title, empty-state)

### DIFF
--- a/src/epic_news/utils/html/template_manager.py
+++ b/src/epic_news/utils/html/template_manager.py
@@ -89,8 +89,14 @@ class TemplateManager:
             return base_title
         if selected_crew == "NEWS" and content_data.get("main_topic"):
             return f"{base_title} - {content_data['main_topic']}"
-        if selected_crew == "SHOPPING" and content_data.get("product_name"):
-            return f"🛒 {content_data['product_name']} - Conseil d'Achat"
+        if selected_crew == "SHOPPING":
+            # SHOPPING carries the name in product_info.name (model_dump); keep the
+            # flat product_name as a legacy fallback.
+            product_info = content_data.get("product_info")
+            name = product_info.get("name") if isinstance(product_info, dict) else None
+            name = name or content_data.get("product_name")
+            if name:
+                return f"🛒 {name} - Conseil d'Achat"
 
         return base_title
 

--- a/src/epic_news/utils/html/template_renderers/shopping_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/shopping_renderer.py
@@ -55,6 +55,13 @@ class ShoppingRenderer(BaseRenderer):
         self._add_recommendations(soup, container, data)
         self._add_user_context(soup, container, data)
 
+        # Empty-state: if a degenerate payload produced no sections, signal it
+        # visibly instead of returning a silently blank wrapper.
+        if not container.find(True):  # type: ignore[union-attr]
+            empty = soup.new_tag("div", attrs={"class": "empty-state"})
+            empty.string = "Aucune donnée d'achat disponible."
+            container.append(empty)  # type: ignore[union-attr]
+
         return str(soup)
 
     @staticmethod
@@ -179,8 +186,11 @@ class ShoppingRenderer(BaseRenderer):
             retailer_td = soup.new_tag("td")
             retailer = price_item.get("retailer") or ""
             url = price_item.get("url")
-            if url:
-                link = soup.new_tag("a", attrs={"href": url, "target": "_blank", "rel": "noopener"})
+            # Only hyperlink safe http(s) schemes; a javascript:/data: URL from
+            # crew output would be a clickable XSS vector (HTML-escaping does not
+            # neutralise the scheme). Otherwise show the retailer as plain text.
+            if isinstance(url, str) and url.strip().lower().startswith(("http://", "https://")):
+                link = soup.new_tag("a", attrs={"href": url.strip(), "target": "_blank", "rel": "noopener"})
                 link.string = retailer
                 retailer_td.append(link)
             else:

--- a/tests/rendering/test_template_manager_rendering/test_template_manager_rendering_snapshots_SHOPPING_build_shopping_.html
+++ b/tests/rendering/test_template_manager_rendering/test_template_manager_rendering_snapshots_SHOPPING_build_shopping_.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>🛒 Conseil d'Achat</title>
+  <title>🛒 Robot de cuisine - Conseil d'Achat</title>
   <script>
     // Initialize theme on page load
     (function() {
@@ -1904,7 +1904,7 @@ a:hover { text-decoration: underline; }
   </button>
 
   <div class="container">
-    <h1>🛒 Conseil d'Achat</h1>
+    <h1>🛒 Robot de cuisine - Conseil d'Achat</h1>
     
     <div class="date-info">
       <p>Généré le 2025-01-01 00:00:00</p>

--- a/tests/utils/html/test_shopping_renderer.py
+++ b/tests/utils/html/test_shopping_renderer.py
@@ -102,6 +102,9 @@ def test_full_model_via_template_manager_renders_all_sections():
     assert "Acheter le X chez Digitec." in html
     assert "Budget 300 CHF, logement 2 pièces." in html
 
+    # Report <title> derives from product_info.name, not the generic fallback.
+    assert "🛒 Aspirateur X - Conseil d'Achat" in html
+
 
 def test_regression_model_dump_is_not_blank():
     """The exact production shape must produce real content, not an empty wrapper."""
@@ -117,10 +120,26 @@ def test_error_key_renders_error_only():
     assert "<section" not in html
 
 
-def test_empty_dict_renders_wrapper_without_crash():
+def test_empty_dict_renders_empty_state_not_blank():
     html = ShoppingRenderer().render({})
     assert '<div class="shopping-advice">' in html
     assert "<section" not in html
+    # A degenerate payload is signalled visibly, not returned silently blank.
+    assert 'class="empty-state"' in html
+
+
+def test_unsafe_url_scheme_is_not_hyperlinked():
+    """A javascript:/data: retailer URL must render as plain text, never an href."""
+    model = _full_model().model_dump()
+    model["switzerland_prices"][0]["url"] = "javascript:alert(1)"
+    model["france_prices"][0]["url"] = "data:text/html,<script>x</script>"
+    html = ShoppingRenderer().render(model)
+    assert "javascript:" not in html
+    assert "data:text/html" not in html
+    assert "<a " not in html  # neither retailer is hyperlinked now
+    # Retailers still shown as plain text.
+    assert "Digitec" in html
+    assert "Fnac" in html
 
 
 def test_price_row_without_url_is_plain_text():


### PR DESCRIPTION
Addresses the 3 CodeRabbit findings on #139 (which I merged before reviewing — my miss).

- **Security (Major):** retailer `url` was interpolated straight into `href`. A `javascript:`/`data:` URL from crew output is a clickable XSS vector — HTML-escaping doesn't neutralise the scheme. Now only `http(s)://` URLs are linked; otherwise the retailer renders as plain text. New test `test_unsafe_url_scheme_is_not_hyperlinked`.
- **Functional (Major):** after #139 the SHOPPING report `<title>` still read the flat `product_name` (removed), so it fell back to the generic "🛒 Conseil d'Achat". `TemplateManager.generate_contextual_title` now reads `product_info.name` (flat `product_name` kept as a legacy fallback). Snapshot regenerated — title is now product-specific.
- **Maintainability (Minor):** a degenerate payload produced a silently blank `<div class="shopping-advice"></div>` — the very symptom #139 targeted. `render()` now appends an `empty-state` div when no section is produced.

Renderer **100%** covered; full suite **837 passed / 5 skipped**; ruff + mypy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)