### PR TITLE
fix(deep_research): phantom markdown files + render agent Markdown in reports

### DIFF
--- a/src/epic_news/crews/deep_research/config/tasks.yaml
+++ b/src/epic_news/crews/deep_research/config/tasks.yaml
@@ -52,10 +52,13 @@ information_collection_task:
     IMPORTANT: Pour chaque source (web ET Wikipedia), vous DEVEZ inclure une URL  précise
     et fonctionnelle. Les sources sans URL ne seront pas considérées comme  valides
     et pourraient compromettre la validité du rapport final.
+    INTERDICTION: Vous ne disposez d'aucun outil d'écriture de fichier. N'annoncez
+    jamais avoir enregistré des données dans des fichiers. Le corpus que vous produisez
+    est transmis directement aux tâches suivantes via le contexte.
   expected_output: >
-    Un corpus de recherche structuré combinant sources web et encyclopédiques :
-    - Un ensemble complet de données brutes (articles, statistiques, etc.) enregistré
-     dans des fichiers markdown dans "output/deep_research/"
+    Un corpus de recherche structuré combinant sources web et encyclopédiques,
+    restitué intégralement dans le texte de votre réponse (aucun fichier n'est écrit) :
+    - Un ensemble complet de données brutes (articles, statistiques, etc.)
     - Une bibliographie annotée détaillée pour CHAQUE source (web et Wikipedia),
       incluant OBLIGATOIREMENT:
       * Un titre descriptif
@@ -80,8 +83,10 @@ data_analysis_task:
     Mener une analyse critique et approfondie du corpus de données sur {topic}.
     Appliquer les méthodes d'analyse définies dans le protocole pour évaluer les
     hypothèses à la lumière des seules preuves rassemblées par la collecte.
-    INTERDICTION ABSOLUE: Vous n'exécutez aucun code et ne disposez d'aucun outil de
-    calcul. Ne JAMAIS inventer de statistiques, de p-values, d'intervalles de confiance,
+    INTERDICTION ABSOLUE: Vous ne disposez d'AUCUN outil: ni exécution de code, ni
+    calcul, ni lecture de fichier. Le corpus complet vous est fourni dans le contexte
+    de la tâche précédente: n'essayez jamais d'ouvrir un fichier, aucun n'a été écrit.
+    Ne JAMAIS inventer de statistiques, de p-values, d'intervalles de confiance,
     de coefficients de corrélation ni de résultats de tests de significativité.
     Ne JAMAIS présenter un chiffre qui ne provient pas explicitement d'une source citée.
     Tout chiffre rapporté doit être accompagné de la source qui le fournit.

--- a/src/epic_news/crews/deep_research/deep_research.py
+++ b/src/epic_news/crews/deep_research/deep_research.py
@@ -73,10 +73,14 @@ class DeepResearchCrew:
     # Data Analyst - Critical analysis and synthesis of the collected corpus
     @agent
     def data_analyst(self) -> Agent:
-        """Data analyst agent for critical synthesis of the collected sources."""
+        """Data analyst agent for critical synthesis of the collected sources.
+
+        Deliberately tool-less: the corpus arrives via task context. Given a FileReadTool
+        it invents plausible filenames and tries to read a corpus nobody ever wrote.
+        """
         return Agent(
             config=self.agents_config["data_analyst"],  # type: ignore[index]
-            tools=[FileReadTool()],
+            tools=[],
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("long"),
             verbose=True,

--- a/src/epic_news/utils/html/template_renderers/base_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/base_renderer.py
@@ -318,6 +318,25 @@ class BaseRenderer(ABC):
         for child in list(fragment.contents):
             container.append(child)
 
+    def render_markdown_inline(
+        self,
+        container: Any,
+        text: str | None,
+    ) -> None:
+        """Convert inline Markdown (bold, links, code) into ``container``.
+
+        Unlike :meth:`render_markdown_block`, this emits no block wrapper, so it is safe
+        inside ``<li>`` or ``<span>`` where a nested ``<p>`` would be wrong. Same safe
+        mode: raw HTML disabled.
+        """
+        if not text:
+            return
+
+        html = _get_markdown_parser().renderInline(text)
+        fragment = BeautifulSoup(html, "html.parser")
+        for child in list(fragment.contents):
+            container.append(child)
+
     def create_soup(self, tag: str = "div", **attrs) -> BeautifulSoup:
         """
         Create a new BeautifulSoup object with a root element.

--- a/src/epic_news/utils/html/template_renderers/deep_research_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/deep_research_renderer.py
@@ -134,9 +134,7 @@ class DeepResearchRenderer(BaseRenderer):
 
         summary_div = soup.new_tag("div")
         summary_div.attrs["class"] = "summary-content"
-        summary_p = soup.new_tag("p")
-        summary_p.string = summary
-        summary_div.append(summary_p)
+        self.render_markdown_block(summary_div, summary)
         section.append(summary_div)
 
         container.append(section)
@@ -163,7 +161,8 @@ class DeepResearchRenderer(BaseRenderer):
         for finding in key_findings:
             li = soup.new_tag("li")
             li.attrs["class"] = "finding-item"
-            li.string = finding
+            # Inline: a nested <p> inside <li> would be wrong.
+            self.render_markdown_inline(li, finding)
             findings_list.append(li)
 
         findings_div.append(findings_list)
@@ -195,18 +194,13 @@ class DeepResearchRenderer(BaseRenderer):
             title_tag.string = section_title
             section_div.append(title_tag)
 
-            # Section content
+            # Section content. Agents write Markdown (**bold**, "- " bullets) inside the
+            # JSON string fields, so render it rather than escaping it into the page.
             content = section_data.get("content", "")
             if content:
                 content_div = soup.new_tag("div")
                 content_div.attrs["class"] = "section-content"
-                # Split content into paragraphs
-                paragraphs = content.split("\n\n")
-                for paragraph in paragraphs:
-                    if paragraph.strip():
-                        p_tag = soup.new_tag("p")
-                        p_tag.string = paragraph.strip()
-                        content_div.append(p_tag)
+                self.render_markdown_block(content_div, content)
                 section_div.append(content_div)
 
             # Add sources for this section
@@ -250,7 +244,8 @@ class DeepResearchRenderer(BaseRenderer):
                         if summary:
                             summary_span = soup.new_tag("span")
                             summary_span.attrs["class"] = "source-summary"
-                            summary_span.string = f" - {summary}"
+                            summary_span.append(" - ")
+                            self.render_markdown_inline(summary_span, summary)
                             details.append(summary_span)
                         li.append(details)
 
@@ -318,9 +313,7 @@ class DeepResearchRenderer(BaseRenderer):
 
         methodology_div = soup.new_tag("div")
         methodology_div.attrs["class"] = "methodology-content"
-        methodology_p = soup.new_tag("p")
-        methodology_p.string = methodology
-        methodology_div.append(methodology_p)
+        self.render_markdown_block(methodology_div, methodology)
         section.append(methodology_div)
 
         container.append(section)

--- a/tests/crews/test_deep_research_capability_contract.py
+++ b/tests/crews/test_deep_research_capability_contract.py
@@ -1,0 +1,79 @@
+"""deep_research agents must not be asked to do what their tools cannot do.
+
+Two production failures came from this mismatch:
+
+* data_analyst was told to save and run Python scripts. CrewAI removed
+  CodeInterpreterTool, so it held only a read-only FileReadTool and called it on the
+  target *directory* -- "File not found: output/deep_research/python_scripts".
+* information_collector was told to save its corpus as markdown files. It has no
+  file-writer, so data_analyst later invented filenames and tried to read a corpus
+  nobody had written -- "File not found: .../crewai_documentation_v1.15.2.md".
+
+These tests pin the contract: no task may promise file writes or code execution, and
+data_analyst stays tool-less so it cannot invent paths to read.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+CONFIG = Path(__file__).resolve().parents[2] / "src/epic_news/crews/deep_research/config"
+
+
+@pytest.fixture(scope="module")
+def tasks() -> dict:
+    return yaml.safe_load((CONFIG / "tasks.yaml").read_text(encoding="utf-8"))
+
+
+@pytest.fixture(scope="module")
+def agents() -> dict:
+    return yaml.safe_load((CONFIG / "agents.yaml").read_text(encoding="utf-8"))
+
+
+def _task_text(task: dict) -> str:
+    return f"{task.get('description', '')}\n{task.get('expected_output', '')}"
+
+
+def test_no_task_instructs_writing_files_into_the_output_dir(tasks):
+    """No agent here can write files; a task must not claim otherwise.
+
+    `output_file:` is fine -- CrewAI writes that itself.
+    """
+    offenders = []
+    for name, task in tasks.items():
+        text = _task_text(task)
+        if 'dans des fichiers markdown dans "output' in text or "python_scripts" in text:
+            offenders.append(name)
+
+    assert not offenders, f"tasks promise file writes no agent can perform: {offenders}"
+
+
+def test_no_task_instructs_code_execution(tasks):
+    """CrewAI removed CodeInterpreterTool; nothing may promise to run code."""
+    banned = ("interpréteur de code", "uv run python", "pip install")
+    offenders = [n for n, t in tasks.items() if any(b in _task_text(t).lower() for b in banned)]
+
+    assert not offenders, f"tasks instruct code execution that cannot happen: {offenders}"
+
+
+def test_agents_yaml_declares_no_deprecated_execution_flags(agents):
+    for name, cfg in agents.items():
+        assert "allow_code_execution" not in cfg, f"{name} sets a deprecated no-op flag"
+        assert "code_execution_mode" not in cfg, f"{name} sets a deprecated no-op flag"
+
+
+def test_agents_yaml_declares_no_tools(agents):
+    """Tools are assigned in Python, never YAML (project convention)."""
+    for name, cfg in agents.items():
+        assert "tools" not in cfg, f"{name} declares tools in YAML"
+
+
+def test_data_analyst_is_tool_less():
+    """Given any file tool it invents filenames; its corpus arrives via context."""
+    from epic_news.crews.deep_research.deep_research import DeepResearchCrew
+
+    analyst = DeepResearchCrew().data_analyst()
+
+    assert analyst.tools == [], f"data_analyst must hold no tools, got {[t.name for t in analyst.tools]}"
+    assert not analyst.allow_code_execution

--- a/tests/crews/test_deep_research_capability_contract.py
+++ b/tests/crews/test_deep_research_capability_contract.py
@@ -18,6 +18,8 @@ from pathlib import Path
 import pytest
 import yaml
 
+from epic_news.crews.deep_research.deep_research import DeepResearchCrew
+
 CONFIG = Path(__file__).resolve().parents[2] / "src/epic_news/crews/deep_research/config"
 
 
@@ -71,8 +73,6 @@ def test_agents_yaml_declares_no_tools(agents):
 
 def test_data_analyst_is_tool_less():
     """Given any file tool it invents filenames; its corpus arrives via context."""
-    from epic_news.crews.deep_research.deep_research import DeepResearchCrew
-
     analyst = DeepResearchCrew().data_analyst()
 
     assert analyst.tools == [], f"data_analyst must hold no tools, got {[t.name for t in analyst.tools]}"

--- a/tests/rendering/test_deep_research_markdown_rendering.py
+++ b/tests/rendering/test_deep_research_markdown_rendering.py
@@ -1,0 +1,98 @@
+"""Agent-authored Markdown must be rendered, not escaped into the page.
+
+The deep_research agents emit Markdown (**bold**, "- " bullets, links, `code`) inside the
+JSON string fields of DeepResearchReport. The renderer used to assign those strings via
+`tag.string = ...`, so a real report shipped literal `**Scalabilité**` and `- ` bullets
+to the reader.
+
+Rendering Markdown means interpreting agent text as markup, so the escaping tests below
+are load-bearing: markdown-it runs with html=False and must never emit a live tag.
+"""
+
+import re
+
+import pytest
+
+from epic_news.utils.html.template_renderers.deep_research_renderer import DeepResearchRenderer
+
+
+@pytest.fixture
+def report() -> dict:
+    return {
+        "title": "Rapport",
+        "topic": "crewai",
+        "executive_summary": "Un **résumé** avec [un lien](https://example.org/a).",
+        "key_findings": ["**Scalabilité** confirmée", "Appeler `crew.kickoff()`"],
+        "methodology": "- première étape\n- seconde étape",
+        "research_sections": [
+            {
+                "title": "Analyse",
+                "content": "**Théorie**\n\n- point A\n- point B",
+                "sources": [
+                    {
+                        "title": "Source",
+                        "url": "https://example.org/src",
+                        "source_type": "web",
+                        "summary": "**Important** détail",
+                    }
+                ],
+            }
+        ],
+        "sources_count": 1,
+        "report_date": "2026-07-10",
+        "confidence_level": "High",
+    }
+
+
+@pytest.fixture
+def html(report) -> str:
+    return DeepResearchRenderer().render(report)
+
+
+def test_no_literal_markdown_survives(html):
+    assert "**" not in html, "literal bold markers reached the page"
+    assert "- point A" not in html, "literal bullet reached the page"
+
+
+def test_block_markdown_becomes_elements(html):
+    assert "<strong>" in html
+    assert "<li>" in html and "<ul>" in html
+
+
+def test_inline_markdown_in_list_items_has_no_nested_paragraph(html):
+    """render_markdown_inline is used inside <li>; a nested <p> would be invalid."""
+    finding = re.search(r'<li class="finding-item">(.*?)</li>', html, re.S)
+    assert finding, "finding item not found"
+    assert "<strong>" in finding.group(1)
+    assert "<p>" not in finding.group(1)
+
+
+def test_code_and_links_render(html):
+    assert "<code>" in html
+    assert 'href="https://example.org/a"' in html
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        "<script>alert(1)</script>",
+        "<img src=x onerror=alert(1)>",
+        "<iframe src='evil'></iframe>",
+    ],
+)
+def test_raw_html_from_agent_text_is_escaped_not_executed(payload):
+    """Interpreting agent output as Markdown must not open an injection hole."""
+    data = {
+        "title": "T",
+        "executive_summary": payload,
+        "key_findings": [payload],
+        "methodology": payload,
+        "research_sections": [{"title": "S", "content": payload, "sources": []}],
+    }
+
+    html = DeepResearchRenderer().render(data)
+
+    assert not re.search(r"<script[\s>]", html), "live <script> tag emitted"
+    assert not re.search(r"<img[\s>]", html), "live <img> tag emitted"
+    assert not re.search(r"<iframe[\s>]", html), "live <iframe> tag emitted"
+    assert "&lt;" in html, "payload was not escaped at all"

--- a/tests/rendering/test_deep_research_markdown_rendering.py
+++ b/tests/rendering/test_deep_research_markdown_rendering.py
@@ -78,6 +78,10 @@ def test_code_and_links_render(html):
         "<script>alert(1)</script>",
         "<img src=x onerror=alert(1)>",
         "<iframe src='evil'></iframe>",
+        # Case variants: HTML tag names are case-insensitive, so the guard must be too.
+        "<SCRIPT>alert(1)</SCRIPT>",
+        "<ImG SrC=x OnErRoR=alert(1)>",
+        '<a href="javascript:alert(1)">x</a>',
     ],
 )
 def test_raw_html_from_agent_text_is_escaped_not_executed(payload):
@@ -92,7 +96,27 @@ def test_raw_html_from_agent_text_is_escaped_not_executed(payload):
 
     html = DeepResearchRenderer().render(data)
 
-    assert not re.search(r"<script[\s>]", html), "live <script> tag emitted"
-    assert not re.search(r"<img[\s>]", html), "live <img> tag emitted"
-    assert not re.search(r"<iframe[\s>]", html), "live <iframe> tag emitted"
+    for tag in ("script", "img", "iframe", "a"):
+        assert not re.search(rf"<{tag}[\s>]", html, re.IGNORECASE), f"live <{tag}> tag emitted"
     assert "&lt;" in html, "payload was not escaped at all"
+
+
+def test_markdown_link_cannot_smuggle_a_javascript_url():
+    """The real vector: markdown-it *does* build <a> tags, so its link validator matters.
+
+    Raw `<a href="javascript:...">` is merely escaped, but `[x](javascript:...)` would be
+    turned into a live anchor if markdown-it's validateLink were disabled.
+    """
+    data = {
+        "title": "T",
+        "executive_summary": "[click](javascript:alert(1))",
+        "key_findings": [],
+        "methodology": "m",
+        "research_sections": [],
+    }
+
+    html = DeepResearchRenderer().render(data)
+
+    assert not re.search(r"""<a[^>]+href\s*=\s*["']?\s*javascript:""", html, re.IGNORECASE), (
+        "markdown link smuggled a javascript: URL into a live anchor"
+    )


### PR DESCRIPTION
Second instance of the same capability mismatch that produced the `python_scripts` error in #149. Surfaced by a live run.

## The failure

```
Error: File not found at path: output/deep_research/crewai_documentation_v1.15.2.md
Error: File not found at path: output/deep_research/synthese_donnees_brutes.md
```

`information_collection_task`'s `expected_output` (tasks.yaml:57-58) demanded the raw corpus be *"enregistré dans des fichiers markdown dans `output/deep_research/`"*. But `information_collector` (`deep_research.py:54-65`) holds `HybridSearchTool`, `ScrapeWebsiteTool`, `FileReadTool` and Wikipedia MCP — **no file writer**.

So nothing ever wrote those files. `data_analyst`, holding a `FileReadTool` and told a corpus existed on disk, invented plausible filenames and tried to read them.

This is the identical defect shape as before: *an instruction to produce artifacts by an agent with no means to produce them.* #149 fixed the `data_analysis_task` half; this is the collection half I missed.

## The fix

The corpus already reaches `data_analyst` via `context=[research_planning_task, information_collection_task]` — no file was ever needed. So:

- `information_collection_task` no longer asks for markdown files, and explicitly states no file-writing tool exists.
- `data_analyst` is now **tool-less**. Given any file tool it fabricates paths to read; its corpus arrives through context. Its task text says so too, since the agent reads the task, not the Python.

## Regression guard

New `test_deep_research_capability_contract.py` pins the whole class of defect:

- no task may promise file writes into `output/` (an `output_file:` key is fine — CrewAI writes that itself)
- no task may instruct code execution (`interpréteur de code`, `uv run python`, `pip install`)
- no `agents.yaml` may set the deprecated `allow_code_execution` / `code_execution_mode` no-ops
- no `agents.yaml` may declare `tools:` (project convention: tools are assigned in Python)
- `data_analyst` holds no tools

Mutation-tested: reintroducing the exact `dans des fichiers markdown dans "output/deep_research/"` instruction fails `test_no_task_instructs_writing_files_into_the_output_dir`. Restoring it passes.

## Verification

`609 passed, 5 skipped, 0 failed`. ruff, mypy, yamllint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deep research workflows to provide research content directly through task context instead of relying on stored files.
  * Prevented data analysis steps from attempting file access, code execution, or calculations unsupported by the workflow.

* **Tests**
  * Added checks to ensure task instructions and agent settings accurately reflect available capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->