### PR TITLE
fix(rendering): render agent Markdown across all renderers

### DIFF
--- a/src/epic_news/utils/html/template_renderers/base_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/base_renderer.py
@@ -12,12 +12,17 @@ Provides shared helper methods for common rendering patterns:
 """
 
 import json
+import warnings
 from abc import ABC, abstractmethod
 from functools import lru_cache
 from typing import Any
 
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, MarkupResemblesLocatorWarning
 from markdown_it import MarkdownIt
+
+# A prose field whose entire value is a bare URL makes BeautifulSoup warn that we probably
+# meant to fetch it. We are parsing rendered Markdown, not a locator; the warning is noise.
+warnings.filterwarnings("ignore", category=MarkupResemblesLocatorWarning)
 
 
 @lru_cache(maxsize=1)
@@ -184,7 +189,7 @@ class BaseRenderer(ABC):
                 ul = soup.new_tag("ul")
                 for item in value:
                     li = soup.new_tag("li")
-                    li.string = str(item)
+                    self.append_prose(li, item)
                     ul.append(li)
                 card.append(ul)
             elif isinstance(value, dict):
@@ -193,11 +198,14 @@ class BaseRenderer(ABC):
                     strong = soup.new_tag("strong")
                     strong.string = f"{sub_key.replace('_', ' ').title()}: "
                     p.append(strong)
-                    p.append(str(sub_val))
+                    self.append_prose(p, sub_val)
                     card.append(p)
             else:
                 p = soup.new_tag("p")
-                p.string = str(value) if value else "N/A"
+                if value:
+                    self.append_prose(p, value)
+                else:
+                    p.string = "N/A"
                 card.append(p)
 
             section.append(card)
@@ -245,7 +253,7 @@ class BaseRenderer(ABC):
                 card_title_text = "Item"
 
             card_title = soup.new_tag("h3")
-            card_title.string = card_title_text
+            self.append_prose(card_title, card_title_text)
             card.append(card_title)
 
             # Render remaining fields
@@ -259,7 +267,10 @@ class BaseRenderer(ABC):
                 strong = soup.new_tag("strong")
                 strong.string = f"{key.replace('_', ' ').title()}: "
                 p.append(strong)
-                p.append(str(value) if value else "N/A")
+                if value:
+                    self.append_prose(p, value)
+                else:
+                    p.append("N/A")
                 card.append(p)
 
             grid.append(card)
@@ -274,7 +285,7 @@ class BaseRenderer(ABC):
         text: str | None,
         title: str,
         icon: str = "",
-        as_markdown: bool = False,
+        as_markdown: bool = True,
     ) -> None:
         """
         Render a simple text section.
@@ -285,7 +296,9 @@ class BaseRenderer(ABC):
             text: Text content
             title: Section title
             icon: Optional emoji icon
-            as_markdown: If True, parse ``text`` as Markdown and render as HTML
+            as_markdown: Parse ``text`` as Markdown (default). Agents write Markdown into
+                the JSON string fields, so escaping it ships literal ``**bold**`` to the
+                reader. Pass False only where whitespace is significant (e.g. poetry).
         """
         if not text:
             return
@@ -336,6 +349,18 @@ class BaseRenderer(ABC):
         fragment = BeautifulSoup(html, "html.parser")
         for child in list(fragment.contents):
             container.append(child)
+
+    def append_prose(self, container: Any, value: Any) -> None:
+        """Append an agent-authored value to ``container``, rendering inline Markdown.
+
+        Crews return JSON, but the model writes Markdown inside the string fields, so a
+        plain ``tag.string = value`` ships literal ``**bold**`` to the reader. Only ``str``
+        values are parsed; numbers, bools and structures are stringified as before.
+        """
+        if isinstance(value, str):
+            self.render_markdown_inline(container, value)
+        else:
+            container.append(str(value))
 
     def create_soup(self, tag: str = "div", **attrs) -> BeautifulSoup:
         """

--- a/src/epic_news/utils/html/template_renderers/book_summary_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/book_summary_renderer.py
@@ -62,7 +62,8 @@ class BookSummaryRenderer(BaseRenderer):
         # Title
         title = data.get("title", "Livre")
         title_tag = soup.new_tag("h2")
-        title_tag.string = f"📖 {title}"
+        title_tag.append("📖 ")
+        self.render_markdown_inline(title_tag, title)
         header_div.append(title_tag)
 
         # Meta information
@@ -75,7 +76,8 @@ class BookSummaryRenderer(BaseRenderer):
         author_strong = soup.new_tag("strong")
         author_strong.string = "✍️ Auteur:"
         author_p.append(author_strong)
-        author_p.append(f" {author}")
+        author_p.append(" ")
+        self.render_markdown_inline(author_p, author)
         meta_div.append(author_p)
 
         # Publication date
@@ -138,7 +140,7 @@ class BookSummaryRenderer(BaseRenderer):
             if chapter_title:
                 li = soup.new_tag("li")
                 link = soup.new_tag("a", href=f"#{chapter_id}")
-                link.string = chapter_title
+                self.render_markdown_inline(link, chapter_title)
                 li.append(link)
                 toc_ul.append(li)
 
@@ -172,7 +174,8 @@ class BookSummaryRenderer(BaseRenderer):
 
                 # Chapter title
                 ch_h4 = soup.new_tag("h4")
-                ch_h4.string = f"📚 Chapitre {ch_num}: {ch_title}"
+                ch_h4.append(f"📚 Chapitre {ch_num}: ")
+                self.render_markdown_inline(ch_h4, ch_title)
                 chapter_div.append(ch_h4)
 
                 # Chapter focus (Markdown -> HTML)
@@ -211,7 +214,8 @@ class BookSummaryRenderer(BaseRenderer):
 
                 # Section title
                 sec_h4 = soup.new_tag("h4")
-                sec_h4.string = f"🔍 {sec_title}"
+                sec_h4.append("🔍 ")
+                self.render_markdown_inline(sec_h4, sec_title)
                 section_div.append(sec_h4)
 
                 # Section content (Markdown -> HTML; headings, lists, tables, bold)

--- a/src/epic_news/utils/html/template_renderers/company_news_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/company_news_renderer.py
@@ -78,7 +78,7 @@ class CompanyNewsRenderer(BaseRenderer):
             h2.string = "📰 Synthèse stratégique 2025"
             header.append(h2)
             p = soup.new_tag("p")
-            p.string = summary
+            self.append_prose(p, summary)
             header.append(p)
             container.append(header)
 
@@ -89,7 +89,8 @@ class CompanyNewsRenderer(BaseRenderer):
         for section in sections:
             section_div = soup.new_tag("section", **{"class": "company-news-section"})
             title = soup.new_tag("h3")
-            title.string = f"📌 {section.get('titre', 'Section')}"
+            title.append("📌 ")
+            self.append_prose(title, section.get("titre", "Section"))
             section_div.append(title)
             articles = section.get("contenu", [])
             for article in articles:
@@ -114,33 +115,35 @@ class CompanyNewsRenderer(BaseRenderer):
                             rel="noopener",
                             **{"class": "company-article-link"},
                         )
-                        a.string = title_text
+                        self.append_prose(a, title_text)
                         article_div.append(a)
                     else:
                         # Fallback if regex doesn't match
                         span = soup.new_tag("span")
-                        span.string = article_title
+                        self.append_prose(span, article_title)
                         article_div.append(span)
                 else:
                     # No markdown link format detected
                     span = soup.new_tag("span")
-                    span.string = article_title or "Article"
+                    self.append_prose(span, article_title or "Article")
                     article_div.append(span)
                 # Meta info
                 meta_div = soup.new_tag("div", **{"class": "company-news-meta"})
                 if article.get("date"):
                     date_span = soup.new_tag("span", **{"class": "company-article-date"})
-                    date_span.string = f"📅 {article['date']}"
+                    date_span.append("📅 ")
+                    self.append_prose(date_span, article["date"])
                     meta_div.append(date_span)
                 if article.get("source"):
                     source_span = soup.new_tag("span", **{"class": "company-article-source"})
-                    source_span.string = f"📰 {article['source']}"
+                    source_span.append("📰 ")
+                    self.append_prose(source_span, article["source"])
                     meta_div.append(source_span)
                 article_div.append(meta_div)
                 # Citation
                 if article.get("citation"):
                     citation_div = soup.new_tag("blockquote", **{"class": "company-article-citation"})
-                    citation_div.string = article["citation"]
+                    self.append_prose(citation_div, article["citation"])
                     article_div.append(citation_div)
                 section_div.append(article_div)
             container.append(section_div)
@@ -155,6 +158,6 @@ class CompanyNewsRenderer(BaseRenderer):
             h4.string = "📝 Notes & sources"
             notes_div.append(h4)
             notes_p = soup.new_tag("p")
-            notes_p.string = notes
+            self.append_prose(notes_p, notes)
             notes_div.append(notes_p)
             container.append(notes_div)

--- a/src/epic_news/utils/html/template_renderers/company_profiler_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/company_profiler_renderer.py
@@ -49,8 +49,7 @@ class CompanyProfilerRenderer(BaseRenderer):
 
         return str(soup)
 
-    @staticmethod
-    def _add_header(soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
+    def _add_header(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         """Add report header with company name."""
         header = soup.new_tag("div", **{"class": "report-header"})  # type: ignore[arg-type]
 
@@ -60,13 +59,12 @@ class CompanyProfilerRenderer(BaseRenderer):
 
         company_name = data.get("company_name", "Entreprise")
         subtitle = soup.new_tag("p", **{"class": "company-name"})  # type: ignore[arg-type]
-        subtitle.string = company_name
+        self.append_prose(subtitle, company_name)
         header.append(subtitle)
 
         container.append(header)
 
-    @staticmethod
-    def _add_core_info(soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
+    def _add_core_info(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         """Add core company information section."""
         core_info = data.get("core_info", {})
         if not core_info:
@@ -88,10 +86,10 @@ class CompanyProfilerRenderer(BaseRenderer):
             ("Siège social", core_info.get("headquarters_location")),
             ("Secteur d'activité", core_info.get("industry_classification")),
             ("Nombre d'employés", core_info.get("employee_count")),
-            ("Chiffre d'affaires", CompanyProfilerRenderer._format_currency(core_info.get("revenue"))),
+            ("Chiffre d'affaires", self._format_currency(core_info.get("revenue"))),
             (
                 "Capitalisation boursière",
-                CompanyProfilerRenderer._format_currency(core_info.get("market_cap")),
+                self._format_currency(core_info.get("market_cap")),
             ),
         ]
 
@@ -101,7 +99,7 @@ class CompanyProfilerRenderer(BaseRenderer):
                 label_tag = soup.new_tag("span", **{"class": "info-label"})  # type: ignore[arg-type]
                 label_tag.string = label
                 value_tag = soup.new_tag("span", **{"class": "info-value"})  # type: ignore[arg-type]
-                value_tag.string = str(value)
+                self.append_prose(value_tag, value)
                 item.append(label_tag)
                 item.append(value_tag)
                 grid.append(item)
@@ -118,7 +116,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             ul = soup.new_tag("ul")
             for activity in activities:
                 li = soup.new_tag("li")
-                li.string = activity
+                self.append_prose(li, activity)
                 ul.append(li)
             activities_div.append(ul)
             section.append(activities_div)
@@ -130,7 +128,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             h3.string = "🎯 Mission"
             mission_div.append(h3)
             p = soup.new_tag("p")
-            p.string = mission
+            self.append_prose(p, mission)
             mission_div.append(p)
             section.append(mission_div)
 
@@ -144,15 +142,14 @@ class CompanyProfilerRenderer(BaseRenderer):
             tags_div = soup.new_tag("div", **{"class": "tags"})  # type: ignore[arg-type]
             for value in values:
                 tag = soup.new_tag("span", **{"class": "tag"})  # type: ignore[arg-type]
-                tag.string = value
+                self.append_prose(tag, value)
                 tags_div.append(tag)
             values_div.append(tags_div)
             section.append(values_div)
 
         container.append(section)
 
-    @staticmethod
-    def _add_history(soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
+    def _add_history(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         """Add company history section."""
         history = data.get("history", {})
         if not history:
@@ -171,7 +168,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             h3.string = "Origine"
             founding_div.append(h3)
             p = soup.new_tag("p")
-            p.string = founding
+            self.append_prose(p, founding)
             founding_div.append(p)
             section.append(founding_div)
 
@@ -185,7 +182,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             ul = soup.new_tag("ul", **{"class": "timeline"})  # type: ignore[arg-type]
             for milestone in milestones:
                 li = soup.new_tag("li")
-                li.string = milestone
+                self.append_prose(li, milestone)
                 ul.append(li)
             milestones_div.append(ul)
             section.append(milestones_div)
@@ -201,20 +198,22 @@ class CompanyProfilerRenderer(BaseRenderer):
                 if isinstance(acq, dict):
                     card = soup.new_tag("div", **{"class": "card"})  # type: ignore[arg-type]
                     for key, val in acq.items():
+                        # Keep the raw key as the label (no title-casing): callers and
+                        # tests rely on the "cible: ..." form. Only the value is prose.
                         p = soup.new_tag("p")
-                        p.string = f"{key}: {val}"
+                        p.append(f"{key}: ")
+                        self.append_prose(p, val)
                         card.append(p)
                     acq_div.append(card)
                 else:
                     p = soup.new_tag("p")
-                    p.string = str(acq)
+                    self.append_prose(p, acq)
                     acq_div.append(p)
             section.append(acq_div)
 
         container.append(section)
 
-    @staticmethod
-    def _add_financials(soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
+    def _add_financials(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         """Add financial analysis section."""
         financials = data.get("financials", {})
         if not financials:
@@ -251,7 +250,10 @@ class CompanyProfilerRenderer(BaseRenderer):
                     tr = soup.new_tag("tr")
                     for val in trend.values():
                         td = soup.new_tag("td")
-                        td.string = str(val) if val is not None else "N/A"
+                        if val is not None:
+                            self.append_prose(td, val)
+                        else:
+                            td.string = "N/A"
                         tr.append(td)
                     tbody.append(tr)
                 table.append(tbody)
@@ -272,7 +274,7 @@ class CompanyProfilerRenderer(BaseRenderer):
                 label = soup.new_tag("span", **{"class": "metric-label"})  # type: ignore[arg-type]
                 label.string = name.replace("_", " ").title()
                 val_span = soup.new_tag("span", **{"class": "metric-value"})  # type: ignore[arg-type]
-                val_span.string = str(value)
+                self.append_prose(val_span, value)
                 metric.append(label)
                 metric.append(val_span)
                 grid.append(metric)
@@ -293,14 +295,14 @@ class CompanyProfilerRenderer(BaseRenderer):
                     label_tag = soup.new_tag("span", **{"class": "info-label"})  # type: ignore[arg-type]
                     label_tag.string = key.replace("_", " ").title()
                     value_tag = soup.new_tag("span", **{"class": "info-value"})  # type: ignore[arg-type]
-                    value_tag.string = str(val)
+                    self.append_prose(value_tag, val)
                     item.append(label_tag)
                     item.append(value_tag)
                     grid.append(item)
                 debt_div.append(grid)
             else:
                 p = soup.new_tag("p")
-                p.string = str(debt)
+                self.append_prose(p, debt)
                 debt_div.append(p)
             section.append(debt_div)
 
@@ -314,15 +316,14 @@ class CompanyProfilerRenderer(BaseRenderer):
             tags_div = soup.new_tag("div", **{"class": "tags"})  # type: ignore[arg-type]
             for investor in investors:
                 tag = soup.new_tag("span", **{"class": "tag investor"})  # type: ignore[arg-type]
-                tag.string = investor
+                self.append_prose(tag, investor)
                 tags_div.append(tag)
             inv_div.append(tags_div)
             section.append(inv_div)
 
         container.append(section)
 
-    @staticmethod
-    def _add_market_position(soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
+    def _add_market_position(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         """Add market position section."""
         market = data.get("market_position", {})
         if not market:
@@ -341,7 +342,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             h3.string = "Part de marché"
             share_div.append(h3)
             p = soup.new_tag("p", **{"class": "big-number"})  # type: ignore[arg-type]
-            p.string = share
+            self.append_prose(p, share)
             share_div.append(p)
             section.append(share_div)
 
@@ -352,7 +353,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             h3.string = "🔍 Paysage concurrentiel"
             landscape_div.append(h3)
             p = soup.new_tag("p")
-            p.string = landscape
+            self.append_prose(p, landscape)
             landscape_div.append(p)
             section.append(landscape_div)
 
@@ -366,7 +367,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             tags_div = soup.new_tag("div", **{"class": "tags"})  # type: ignore[arg-type]
             for competitor in competitors:
                 tag = soup.new_tag("span", **{"class": "tag competitor"})  # type: ignore[arg-type]
-                tag.string = competitor
+                self.append_prose(tag, competitor)
                 tags_div.append(tag)
             comp_div.append(tags_div)
             section.append(comp_div)
@@ -381,7 +382,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             ul = soup.new_tag("ul", **{"class": "advantages-list"})  # type: ignore[arg-type]
             for adv in advantages:
                 li = soup.new_tag("li")
-                li.string = adv
+                self.append_prose(li, adv)
                 ul.append(li)
             adv_div.append(ul)
             section.append(adv_div)
@@ -396,7 +397,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             ul = soup.new_tag("ul")
             for opp in opportunities:
                 li = soup.new_tag("li")
-                li.string = opp
+                self.append_prose(li, opp)
                 ul.append(li)
             opp_div.append(ul)
             section.append(opp_div)
@@ -411,15 +412,14 @@ class CompanyProfilerRenderer(BaseRenderer):
             ul = soup.new_tag("ul")
             for challenge in challenges:
                 li = soup.new_tag("li")
-                li.string = challenge
+                self.append_prose(li, challenge)
                 ul.append(li)
             chal_div.append(ul)
             section.append(chal_div)
 
         container.append(section)
 
-    @staticmethod
-    def _add_products_services(soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
+    def _add_products_services(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         """Add products and services section."""
         products = data.get("products_and_services", {})
         if not products:
@@ -441,7 +441,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             ul = soup.new_tag("ul")
             for product in core_products:
                 li = soup.new_tag("li")
-                li.string = product
+                self.append_prose(li, product)
                 ul.append(li)
             core_div.append(ul)
             section.append(core_div)
@@ -456,7 +456,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             tags_div = soup.new_tag("div", **{"class": "tags"})  # type: ignore[arg-type]
             for launch in launches:
                 tag = soup.new_tag("span", **{"class": "tag new"})  # type: ignore[arg-type]
-                tag.string = launch
+                self.append_prose(tag, launch)
                 tags_div.append(tag)
             launch_div.append(tags_div)
             section.append(launch_div)
@@ -468,7 +468,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             h3.string = "💵 Stratégie de prix"
             pricing_div.append(h3)
             p = soup.new_tag("p")
-            p.string = pricing
+            self.append_prose(p, pricing)
             pricing_div.append(p)
             section.append(pricing_div)
 
@@ -482,15 +482,14 @@ class CompanyProfilerRenderer(BaseRenderer):
             tags_div = soup.new_tag("div", **{"class": "tags"})  # type: ignore[arg-type]
             for segment in segments:
                 tag = soup.new_tag("span", **{"class": "tag segment"})  # type: ignore[arg-type]
-                tag.string = segment
+                self.append_prose(tag, segment)
                 tags_div.append(tag)
             seg_div.append(tags_div)
             section.append(seg_div)
 
         container.append(section)
 
-    @staticmethod
-    def _add_management(soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
+    def _add_management(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         """Add management section."""
         management = data.get("management", {})
         if not management:
@@ -518,12 +517,12 @@ class CompanyProfilerRenderer(BaseRenderer):
                     role = exec_info.get("role", exec_info.get("position", exec_info.get("titre", "")))
 
                     name_tag = soup.new_tag("h4")
-                    name_tag.string = str(name)
+                    self.append_prose(name_tag, name)
                     card.append(name_tag)
 
                     if role:
                         role_tag = soup.new_tag("p", **{"class": "role"})  # type: ignore[arg-type]
-                        role_tag.string = str(role)
+                        self.append_prose(role_tag, role)
                         card.append(role_tag)
 
                     grid.append(card)
@@ -540,7 +539,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             ul = soup.new_tag("ul")
             for member in board:
                 li = soup.new_tag("li")
-                li.string = member
+                self.append_prose(li, member)
                 ul.append(li)
             board_div.append(ul)
             section.append(board_div)
@@ -552,14 +551,13 @@ class CompanyProfilerRenderer(BaseRenderer):
             h3.string = "🌟 Culture d'entreprise"
             culture_div.append(h3)
             p = soup.new_tag("p")
-            p.string = culture
+            self.append_prose(p, culture)
             culture_div.append(p)
             section.append(culture_div)
 
         container.append(section)
 
-    @staticmethod
-    def _add_legal_compliance(soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
+    def _add_legal_compliance(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         """Add legal compliance section."""
         legal = data.get("legal_compliance", {})
         if not legal:
@@ -578,7 +576,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             h3.string = "Cadre réglementaire"
             framework_div.append(h3)
             p = soup.new_tag("p")
-            p.string = framework
+            self.append_prose(p, framework)
             framework_div.append(p)
             section.append(framework_div)
 
@@ -592,7 +590,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             ul = soup.new_tag("ul")
             for item in history:
                 li = soup.new_tag("li")
-                li.string = item
+                self.append_prose(li, item)
                 ul.append(li)
             hist_div.append(ul)
             section.append(hist_div)
@@ -607,7 +605,7 @@ class CompanyProfilerRenderer(BaseRenderer):
             ul = soup.new_tag("ul")
             for item in litigation:
                 li = soup.new_tag("li")
-                li.string = item
+                self.append_prose(li, item)
                 ul.append(li)
             lit_div.append(ul)
             section.append(lit_div)

--- a/src/epic_news/utils/html/template_renderers/cooking_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/cooking_renderer.py
@@ -60,14 +60,15 @@ class CookingRenderer(BaseRenderer):
         # Title
         title = data.get("recipe_title", data.get("name", "Recette"))
         title_tag = soup.new_tag("h1", attrs={"class": "recipe-title"})
-        title_tag.string = f"🍽️ {title}"
+        title_tag.append("🍽️ ")
+        self.append_prose(title_tag, title)
         header.append(title_tag)
 
         # Description
         description = data.get("description", "")
         if description:
             desc_tag = soup.new_tag("p", attrs={"class": "recipe-description"})
-            desc_tag.string = description
+            self.append_prose(desc_tag, description)
             header.append(desc_tag)
 
         # Add recipe type badge if available
@@ -163,7 +164,8 @@ class CookingRenderer(BaseRenderer):
         ing_list = soup.new_tag("ul", attrs={"class": "ingredients-list"})
         for ingredient in ingredients:
             ing_item = soup.new_tag("li")
-            ing_item.string = f"🥄 {ingredient}"
+            ing_item.append("🥄 ")
+            self.append_prose(ing_item, ingredient)
             ing_list.append(ing_item)
 
         ingredients_section.append(ing_list)
@@ -186,7 +188,7 @@ class CookingRenderer(BaseRenderer):
         ins_list = soup.new_tag("ol", attrs={"class": "instructions-list"})
         for instruction in instructions:
             ins_item = soup.new_tag("li")
-            ins_item.string = instruction
+            self.append_prose(ins_item, instruction)
             ins_list.append(ins_item)
 
         instructions_section.append(ins_list)
@@ -209,12 +211,12 @@ class CookingRenderer(BaseRenderer):
             notes_list = soup.new_tag("ul", attrs={"class": "notes-list"})
             for note in chef_notes:
                 note_item = soup.new_tag("li")
-                note_item.string = str(note)
+                self.append_prose(note_item, note)
                 notes_list.append(note_item)
             notes_section.append(notes_list)
         else:
             notes_content = soup.new_tag("p")
-            notes_content.string = str(chef_notes)
+            self.append_prose(notes_content, chef_notes)
             notes_section.append(notes_content)
 
         container.append(notes_section)
@@ -236,12 +238,13 @@ class CookingRenderer(BaseRenderer):
             nutrition_list = soup.new_tag("ul", attrs={"class": "nutrition-list"})
             for key, value in nutritional_info.items():
                 nutrition_item = soup.new_tag("li")
-                nutrition_item.string = f"{key.replace('_', ' ').title()}: {value}"
+                nutrition_item.append(f"{key.replace('_', ' ').title()}: ")
+                self.append_prose(nutrition_item, value)
                 nutrition_list.append(nutrition_item)
             nutrition_section.append(nutrition_list)
         else:
             nutrition_content = soup.new_tag("p")
-            nutrition_content.string = str(nutritional_info)
+            self.append_prose(nutrition_content, nutritional_info)
             nutrition_section.append(nutrition_content)
 
         container.append(nutrition_section)

--- a/src/epic_news/utils/html/template_renderers/cross_reference_report_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/cross_reference_report_renderer.py
@@ -3,8 +3,9 @@ This module contains the renderer for the Cross-Reference Report.
 """
 
 from html import escape
+from typing import Any
 
-from epic_news.utils.html.template_renderers.base_renderer import BaseRenderer
+from epic_news.utils.html.template_renderers.base_renderer import BaseRenderer, _get_markdown_parser
 
 
 class CrossReferenceReportRenderer(BaseRenderer):
@@ -27,24 +28,36 @@ class CrossReferenceReportRenderer(BaseRenderer):
         confidence = data.get("confidence_assessment", "N/A")
         gaps = data.get("information_gaps", [])
 
-        html = f"<h1>Cross-Reference Intelligence Report: {escape(str(report_target))}</h1>"
-        html += f"<h2>Executive Summary</h2><p>{escape(str(executive_summary))}</p>"
+        html = f"<h1>Cross-Reference Intelligence Report: {self._prose(report_target)}</h1>"
+        html += f"<h2>Executive Summary</h2><p>{self._prose(executive_summary)}</p>"
 
         html += "<h2>Detailed Findings</h2>"
         html += self._render_dict(detailed_findings)
 
-        html += f"<h2>Confidence Assessment</h2><p>{escape(str(confidence))}</p>"
+        html += f"<h2>Confidence Assessment</h2><p>{self._prose(confidence)}</p>"
 
         html += "<h2>Information Gaps</h2>"
         if gaps:
             html += "<ul>"
             for gap in gaps:
-                html += f"<li>{escape(str(gap))}</li>"
+                html += f"<li>{self._prose(gap)}</li>"
             html += "</ul>"
         else:
             html += "<p>No information gaps identified.</p>"
 
         return html
+
+    @staticmethod
+    def _prose(value: Any) -> str:
+        """Render an agent-authored value as safe inline HTML.
+
+        Strings are parsed as inline Markdown (bold, links, code); non-strings are
+        stringified and escaped. The Markdown parser is configured with ``html=False``,
+        so any literal HTML in the source text is escaped, not injected.
+        """
+        if isinstance(value, str):
+            return str(_get_markdown_parser().renderInline(value))
+        return escape(str(value))
 
     def _render_dict(self, data: dict) -> str:
         """Renders a dictionary into an HTML list."""
@@ -57,7 +70,7 @@ class CrossReferenceReportRenderer(BaseRenderer):
             elif isinstance(value, list):
                 html += self._render_list(value)
             else:
-                html += f" {escape(str(value))}"
+                html += f" {self._prose(value)}"
             html += "</li>"
         html += "</ul>"
         return html
@@ -72,7 +85,7 @@ class CrossReferenceReportRenderer(BaseRenderer):
             elif isinstance(item, list):
                 html += self._render_list(item)
             else:
-                html += escape(str(item))
+                html += self._prose(item)
             html += "</li>"
         html += "</ul>"
         return html

--- a/src/epic_news/utils/html/template_renderers/deep_research_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/deep_research_renderer.py
@@ -81,19 +81,21 @@ class DeepResearchRenderer(BaseRenderer):
         header = soup.new_tag("div")
         header.attrs["class"] = "report-header"
 
-        # Title
+        # Title. The emoji is ours; the title is agent-authored and may carry Markdown.
         title = data.get("title", "Rapport de Recherche Approfondie")
         title_tag = soup.new_tag("h1")
         title_tag.attrs["class"] = "report-title"
-        title_tag.string = f"🔬 {title}"
+        title_tag.append("🔬 ")
+        self.append_prose(title_tag, title)
         header.append(title_tag)
 
-        # Topic
+        # Topic. "Sujet: " is our label; the topic itself is agent-authored.
         topic = data.get("topic", "")
         if topic:
             topic_tag = soup.new_tag("h2")
             topic_tag.attrs["class"] = "report-topic"
-            topic_tag.string = f"Sujet: {topic}"
+            topic_tag.append("Sujet: ")
+            self.append_prose(topic_tag, topic)
             header.append(topic_tag)
 
         # Metadata
@@ -218,7 +220,9 @@ class DeepResearchRenderer(BaseRenderer):
                     li = soup.new_tag("li")
                     li.attrs["class"] = "source-item"
 
-                    # Source title and URL
+                    # Source title and URL. Kept literal on purpose: this text sits inside
+                    # an <a>, and the Markdown parser has linkify enabled, so rendering a
+                    # title containing a bare URL would nest an <a> inside an <a>.
                     source_title = source.get("title", "Source")
                     url = source.get("url", "")
                     if url:
@@ -228,7 +232,8 @@ class DeepResearchRenderer(BaseRenderer):
                         link.string = source_title
                         li.append(link)
                     else:
-                        li.string = source_title
+                        # Outside an anchor there is no nesting hazard.
+                        self.append_prose(li, source_title)
 
                     # Source type and summary
                     source_type = source.get("source_type", "")

--- a/src/epic_news/utils/html/template_renderers/financial_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/financial_renderer.py
@@ -59,7 +59,11 @@ class FinancialRenderer(BaseRenderer):
 
         title_tag = soup.new_tag("h2")
         title = data.get("title")
-        title_tag.string = f"💰 {title}" if title else "💰 Rapport Financier"
+        if title:
+            title_tag.append("💰 ")
+            self.render_markdown_inline(title_tag, title)
+        else:
+            title_tag.string = "💰 Rapport Financier"
         header_div.append(title_tag)
 
         # Add date if available
@@ -84,7 +88,7 @@ class FinancialRenderer(BaseRenderer):
         summary_div.append(title_tag)
 
         summary_p = soup.new_tag("p")
-        summary_p.string = summary
+        self.render_markdown_inline(summary_p, summary)
         summary_div.append(summary_p)
 
         container.append(summary_div)
@@ -115,17 +119,17 @@ class FinancialRenderer(BaseRenderer):
             details = item.get("details")
             if asset_class:
                 section_h4 = soup.new_tag("h4")
-                section_h4.string = f"{asset_class}"
+                self.render_markdown_inline(section_h4, asset_class)
                 section_div.append(section_h4)
             if summary:
                 summary_p = soup.new_tag("p")
-                summary_p.string = summary
+                self.render_markdown_inline(summary_p, summary)
                 section_div.append(summary_p)
             if details and isinstance(details, list):
                 details_ul = soup.new_tag("ul")
                 for detail in details:
                     li = soup.new_tag("li")
-                    li.string = str(detail)
+                    self.append_prose(li, detail)
                     details_ul.append(li)
                 section_div.append(details_ul)
             analysis_div.append(section_div)
@@ -157,14 +161,13 @@ class FinancialRenderer(BaseRenderer):
             asset_class = sugg.get("asset_class")
             suggestion = sugg.get("suggestion")
             rationale = sugg.get("rationale")
-            li_content = ""
             if asset_class:
-                li_content += f"[{asset_class}] "
+                li.append(f"[{asset_class}] ")
             if suggestion:
-                li_content += suggestion
+                self.render_markdown_inline(li, suggestion)
             if rationale:
-                li_content += f"\n→ {rationale}"
-            li.string = li_content
+                li.append(" → ")
+                self.render_markdown_inline(li, rationale)
             sugg_ul.append(li)
         rec_div.append(sugg_ul)
 

--- a/src/epic_news/utils/html/template_renderers/generic_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/generic_renderer.py
@@ -71,10 +71,8 @@ class GenericRenderer(BaseRenderer):
                 title_tag.string = field.title()
                 section_div.append(title_tag)
 
-                # Section content
-                content_p = soup.new_tag("p")
-                content_p.string = value
-                section_div.append(content_p)
+                # Section content (agent-authored prose may contain Markdown)
+                self.render_markdown_block(section_div, value)
 
                 content_div.append(section_div)
 
@@ -93,11 +91,19 @@ class GenericRenderer(BaseRenderer):
                 for item in value:
                     li = soup.new_tag("li")
                     if isinstance(item, dict):
-                        # Handle dict items
-                        item_str = ", ".join([f"{k}: {v}" for k, v in item.items() if v])
-                        li.string = item_str
+                        # Handle dict items: keys are labels (literal), values are
+                        # agent-authored prose that may contain Markdown.
+                        first = True
+                        for k, v in item.items():
+                            if not v:
+                                continue
+                            if not first:
+                                li.append(", ")
+                            li.append(f"{k}: ")
+                            self.append_prose(li, v)
+                            first = False
                     else:
-                        li.string = str(item)
+                        self.append_prose(li, item)
                     ul.append(li)
 
                 section_div.append(ul)

--- a/src/epic_news/utils/html/template_renderers/geospatial_analysis_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/geospatial_analysis_renderer.py
@@ -16,6 +16,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from bs4 import BeautifulSoup
+
 from .base_renderer import BaseRenderer
 
 
@@ -31,7 +33,7 @@ class GeospatialAnalysisRenderer(BaseRenderer):
         soup = self.create_soup("div", class_="geospatial-report")
         container = soup.div
 
-        self.add_report_header(soup, container, "🗺️ Analyse Géospatiale", data.get("company_name"))
+        self._add_report_header(soup, container, "🗺️ Analyse Géospatiale", data.get("company_name"))
         self.render_list_as_cards(
             soup, container, data.get("physical_locations"), "Emplacements Physiques", "📍", "location-card"
         )
@@ -57,3 +59,17 @@ class GeospatialAnalysisRenderer(BaseRenderer):
         self.add_raw_json_section(soup, container, data, "Voir les données brutes")
 
         return str(soup)
+
+    def _add_report_header(
+        self, soup: BeautifulSoup, container: Any, title: str, subtitle: str | None
+    ) -> None:
+        """Like ``add_report_header``, but renders ``subtitle`` (agent-authored company name) as Markdown."""
+        header = soup.new_tag("div", **{"class": "report-header"})  # type: ignore[arg-type]
+        h1 = soup.new_tag("h1")
+        h1.string = title
+        header.append(h1)
+        if subtitle:
+            h2 = soup.new_tag("h2")
+            self.render_markdown_inline(h2, subtitle)
+            header.append(h2)
+        container.append(header)

--- a/src/epic_news/utils/html/template_renderers/holiday_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/holiday_renderer.py
@@ -77,7 +77,7 @@ class HolidayRenderer(BaseRenderer):
         section.append(title)
 
         intro_div = soup.new_tag("div", **{"class": "intro-content"})  # type: ignore[arg-type]
-        intro_div.string = data["introduction"]
+        self.render_markdown_block(intro_div, data["introduction"])
         section.append(intro_div)
 
         container.append(section)
@@ -97,7 +97,7 @@ class HolidayRenderer(BaseRenderer):
         toc_list = soup.new_tag("ul", **{"class": "toc-list"})  # type: ignore[arg-type]
         for item in toc_items:
             li = soup.new_tag("li")
-            li.string = item
+            self.append_prose(li, item)
             toc_list.append(li)
 
         section.append(toc_list)
@@ -140,7 +140,9 @@ class HolidayRenderer(BaseRenderer):
 
                     # Description
                     desc_div = soup.new_tag("div", **{"class": "activity-description"})  # type: ignore[arg-type]
-                    desc_div.string = activity.get("description", "Description non disponible")
+                    self.render_markdown_block(
+                        desc_div, activity.get("description", "Description non disponible")
+                    )
                     activity_div.append(desc_div)
 
                     activities_div.append(activity_div)
@@ -168,7 +170,7 @@ class HolidayRenderer(BaseRenderer):
 
             # Name
             name_h3 = soup.new_tag("h3", **{"class": "accommodation-name"})  # type: ignore[arg-type]
-            name_h3.string = acc.get("name", "Nom non spécifié")
+            self.append_prose(name_h3, acc.get("name", "Nom non spécifié"))
             acc_div.append(name_h3)
 
             # Address
@@ -186,7 +188,7 @@ class HolidayRenderer(BaseRenderer):
             # Description
             if acc.get("description"):
                 desc_div = soup.new_tag("div", **{"class": "accommodation-description"})  # type: ignore[arg-type]
-                desc_div.string = acc["description"]
+                self.render_markdown_block(desc_div, acc["description"])
                 acc_div.append(desc_div)
 
             # Amenities
@@ -231,7 +233,7 @@ class HolidayRenderer(BaseRenderer):
 
                 # Name
                 name_h3 = soup.new_tag("h3", **{"class": "restaurant-name"})  # type: ignore[arg-type]
-                name_h3.string = restaurant.get("name", "Nom non spécifié")
+                self.append_prose(name_h3, restaurant.get("name", "Nom non spécifié"))
                 rest_div.append(name_h3)
 
                 # Location
@@ -255,7 +257,7 @@ class HolidayRenderer(BaseRenderer):
                 # Description
                 if restaurant.get("description"):
                     desc_div = soup.new_tag("div", **{"class": "restaurant-description"})  # type: ignore[arg-type]
-                    desc_div.string = restaurant["description"]
+                    self.render_markdown_block(desc_div, restaurant["description"])
                     rest_div.append(desc_div)
 
                 # Dietary options
@@ -294,7 +296,7 @@ class HolidayRenderer(BaseRenderer):
             spec_list = soup.new_tag("ul")
             for specialty in specialties:
                 li = soup.new_tag("li")
-                li.string = specialty
+                self.append_prose(li, specialty)
                 spec_list.append(li)
             spec_div.append(spec_list)
             section.append(spec_div)
@@ -338,12 +340,12 @@ class HolidayRenderer(BaseRenderer):
 
                 # Category
                 cat_td = soup.new_tag("td")
-                cat_td.string = item.get("category", "N/A")
+                self.append_prose(cat_td, item.get("category", "N/A"))
                 row.append(cat_td)
 
                 # Item
                 item_td = soup.new_tag("td")
-                item_td.string = item.get("item", "N/A")
+                self.append_prose(item_td, item.get("item", "N/A"))
                 row.append(item_td)
 
                 # Cost
@@ -355,7 +357,7 @@ class HolidayRenderer(BaseRenderer):
 
                 # Notes
                 notes_td = soup.new_tag("td")
-                notes_td.string = item.get("notes", "")
+                self.append_prose(notes_td, item.get("notes", ""))
                 row.append(notes_td)
 
                 tbody.append(row)
@@ -372,7 +374,8 @@ class HolidayRenderer(BaseRenderer):
         # Notes
         if budget.get("notes"):
             notes_div = soup.new_tag("div", **{"class": "budget-notes"})  # type: ignore[arg-type]
-            notes_div.string = f"📝 {budget['notes']}"
+            notes_div.append("📝 ")
+            self.append_prose(notes_div, budget["notes"])
             section.append(notes_div)
 
         container.append(section)
@@ -419,7 +422,7 @@ class HolidayRenderer(BaseRenderer):
                     cat_list = soup.new_tag("ul")
                     for item in items:
                         li = soup.new_tag("li")
-                        li.string = item
+                        self.append_prose(li, item)
                         cat_list.append(li)
                     cat_div.append(cat_list)
                     packing_div.append(cat_div)
@@ -437,7 +440,7 @@ class HolidayRenderer(BaseRenderer):
             safety_list = soup.new_tag("ul")
             for tip in safety_tips:
                 li = soup.new_tag("li")
-                li.string = tip
+                self.append_prose(li, tip)
                 safety_list.append(li)
             safety_div.append(safety_list)
             section.append(safety_div)
@@ -452,9 +455,11 @@ class HolidayRenderer(BaseRenderer):
 
             for contact in emergency:
                 contact_div = soup.new_tag("div", **{"class": "emergency-contact"})  # type: ignore[arg-type]
-                contact_div.string = f"{contact.get('service', 'Service')}: {contact.get('number', 'N/A')}"
+                contact_div.append(f"{contact.get('service', 'Service')}: {contact.get('number', 'N/A')}")
                 if contact.get("notes"):
-                    contact_div.string += f" ({contact['notes']})"  # type: ignore[operator]
+                    contact_div.append(" (")
+                    self.append_prose(contact_div, contact["notes"])
+                    contact_div.append(")")
                 emergency_div.append(contact_div)
 
             section.append(emergency_div)
@@ -500,10 +505,10 @@ class HolidayRenderer(BaseRenderer):
                 li = soup.new_tag("li")
                 if source.get("url"):
                     link = soup.new_tag("a", href=source["url"], target="_blank")
-                    link.string = source.get("title", source["url"])
+                    self.append_prose(link, source.get("title", source["url"]))
                     li.append(link)
                 else:
-                    li.string = source.get("title", "Source sans titre")
+                    self.append_prose(li, source.get("title", "Source sans titre"))
                 sources_list.append(li)
 
             sources_div.append(sources_list)
@@ -526,12 +531,12 @@ class HolidayRenderer(BaseRenderer):
                     item_div.append(img)
                 else:
                     link = soup.new_tag("a", href=media_item.get("url", ""), target="_blank")
-                    link.string = media_item.get("caption", "Média")
+                    self.append_prose(link, media_item.get("caption", "Média"))
                     item_div.append(link)
 
                 if media_item.get("caption"):
                     caption_div = soup.new_tag("div", **{"class": "media-caption"})  # type: ignore[arg-type]
-                    caption_div.string = media_item["caption"]
+                    self.append_prose(caption_div, media_item["caption"])
                     item_div.append(caption_div)
 
                 media_div.append(item_div)

--- a/src/epic_news/utils/html/template_renderers/hr_intelligence_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/hr_intelligence_renderer.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from bs4 import BeautifulSoup
+
 from .base_renderer import BaseRenderer
 
 
@@ -32,7 +34,7 @@ class HRIntelligenceRenderer(BaseRenderer):
         soup = self.create_soup("div", class_="hr-intelligence-report")
         container = soup.div
 
-        self.add_report_header(soup, container, "👥 Intelligence RH", data.get("company_name"))
+        self._add_report_header(soup, container, "👥 Intelligence RH", data.get("company_name"))
         self.render_text_section(
             soup, container, data.get("summary_and_recommendations"), "Résumé et Recommandations", "📋"
         )
@@ -55,3 +57,17 @@ class HRIntelligenceRenderer(BaseRenderer):
         self.add_raw_json_section(soup, container, data, "Voir les données brutes")
 
         return str(soup)
+
+    def _add_report_header(
+        self, soup: BeautifulSoup, container: Any, title: str, subtitle: str | None
+    ) -> None:
+        """Like ``add_report_header``, but renders ``subtitle`` (agent-authored company name) as Markdown."""
+        header = soup.new_tag("div", **{"class": "report-header"})  # type: ignore[arg-type]
+        h1 = soup.new_tag("h1")
+        h1.string = title
+        header.append(h1)
+        if subtitle:
+            h2 = soup.new_tag("h2")
+            self.render_markdown_inline(h2, subtitle)
+            header.append(h2)
+        container.append(header)

--- a/src/epic_news/utils/html/template_renderers/legal_analysis_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/legal_analysis_renderer.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from bs4 import BeautifulSoup
+
 from .base_renderer import BaseRenderer
 
 
@@ -32,7 +34,7 @@ class LegalAnalysisRenderer(BaseRenderer):
         soup = self.create_soup("div", class_="legal-analysis-report")
         container = soup.div
 
-        self.add_report_header(soup, container, "⚖️ Analyse Juridique", data.get("company_name"))
+        self._add_report_header(soup, container, "⚖️ Analyse Juridique", data.get("company_name"))
         self.render_dict_as_cards(
             soup, container, data.get("compliance_assessment"), "Évaluation de la Conformité", "✅"
         )
@@ -57,3 +59,17 @@ class LegalAnalysisRenderer(BaseRenderer):
         self.add_raw_json_section(soup, container, data, "Voir les données brutes")
 
         return str(soup)
+
+    def _add_report_header(
+        self, soup: BeautifulSoup, container: Any, title: str, subtitle: str | None
+    ) -> None:
+        """Like ``add_report_header``, but renders ``subtitle`` (agent-authored company name) as Markdown."""
+        header = soup.new_tag("div", **{"class": "report-header"})  # type: ignore[arg-type]
+        h1 = soup.new_tag("h1")
+        h1.string = title
+        header.append(h1)
+        if subtitle:
+            h2 = soup.new_tag("h2")
+            self.render_markdown_inline(h2, subtitle)
+            header.append(h2)
+        container.append(header)

--- a/src/epic_news/utils/html/template_renderers/meeting_prep_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/meeting_prep_renderer.py
@@ -49,7 +49,7 @@ class MeetingPrepRenderer(BaseRenderer):
         if "title" in data:
             title_h2 = soup.new_tag("h2")
             title_h2.attrs["class"] = ["meeting-title"]  # type: ignore[assignment]
-            title_h2.string = data["title"]
+            self.render_markdown_inline(title_h2, data["title"])
             container.append(title_h2)  # type: ignore[union-attr]
 
         # Add summary
@@ -73,7 +73,6 @@ class MeetingPrepRenderer(BaseRenderer):
         # Add additional resources
         self._add_additional_resources(soup, container, data)
 
-
         # Now that we're using attrs["class"] instead of class_, we don't need to replace class_ with class
         return str(soup)
 
@@ -87,7 +86,7 @@ class MeetingPrepRenderer(BaseRenderer):
         summary_div.attrs["class"] = ["meeting-summary"]  # type: ignore[assignment]
 
         summary_p = soup.new_tag("p")
-        summary_p.string = summary
+        self.render_markdown_inline(summary_p, summary)
         summary_div.append(summary_p)
 
         container.append(summary_div)
@@ -116,7 +115,8 @@ class MeetingPrepRenderer(BaseRenderer):
             strong = soup.new_tag("strong")
             strong.string = "Nom:"
             name_p.append(strong)
-            name_p.append(f" {company_name}")
+            name_p.append(" ")
+            self.render_markdown_inline(name_p, company_name)
             profile_div.append(name_p)
 
         # Industry
@@ -126,7 +126,8 @@ class MeetingPrepRenderer(BaseRenderer):
             strong = soup.new_tag("strong")
             strong.string = "Secteur:"
             industry_p.append(strong)
-            industry_p.append(f" {industry}")
+            industry_p.append(" ")
+            self.render_markdown_inline(industry_p, industry)
             profile_div.append(industry_p)
 
         # Key products
@@ -139,7 +140,10 @@ class MeetingPrepRenderer(BaseRenderer):
             products_p.append(" ")
 
             products_list = soup.new_tag("span")
-            products_list.string = ", ".join(key_products)
+            for i, product in enumerate(key_products):
+                if i:
+                    products_list.append(", ")
+                self.render_markdown_inline(products_list, product)
             products_p.append(products_list)
             profile_div.append(products_p)
 
@@ -150,7 +154,8 @@ class MeetingPrepRenderer(BaseRenderer):
             strong = soup.new_tag("strong")
             strong.string = "Position sur le marché:"
             position_p.append(strong)
-            position_p.append(f" {market_position}")
+            position_p.append(" ")
+            self.render_markdown_inline(position_p, market_position)
             profile_div.append(position_p)
 
         section.append(profile_div)
@@ -181,7 +186,7 @@ class MeetingPrepRenderer(BaseRenderer):
             name = participant.get("name")
             if name:
                 name_h4 = soup.new_tag("h4")
-                name_h4.string = name
+                self.render_markdown_inline(name_h4, name)
                 participant_div.append(name_h4)
 
             # Role
@@ -191,7 +196,8 @@ class MeetingPrepRenderer(BaseRenderer):
                 strong = soup.new_tag("strong")
                 strong.string = "Rôle:"
                 role_p.append(strong)
-                role_p.append(f" {role}")
+                role_p.append(" ")
+                self.render_markdown_inline(role_p, role)
                 participant_div.append(role_p)
 
             # Background
@@ -201,7 +207,8 @@ class MeetingPrepRenderer(BaseRenderer):
                 strong = soup.new_tag("strong")
                 strong.string = "Profil:"
                 background_p.append(strong)
-                background_p.append(f" {background}")
+                background_p.append(" ")
+                self.render_markdown_inline(background_p, background)
                 participant_div.append(background_p)
 
             participants_div.append(participant_div)
@@ -227,7 +234,7 @@ class MeetingPrepRenderer(BaseRenderer):
         overview_div.attrs["class"] = ["industry-overview"]  # type: ignore[assignment]
 
         overview_p = soup.new_tag("p")
-        overview_p.string = industry_overview
+        self.render_markdown_inline(overview_p, industry_overview)
         overview_div.append(overview_p)
 
         section.append(overview_div)
@@ -257,7 +264,7 @@ class MeetingPrepRenderer(BaseRenderer):
             # Topic as heading
             topic = point.get("topic", "")
             point_h4 = soup.new_tag("h4")
-            point_h4.string = f"{topic}"
+            self.render_markdown_inline(point_h4, topic)
             point_div.append(point_h4)
 
             # Key points as bullet list
@@ -275,7 +282,7 @@ class MeetingPrepRenderer(BaseRenderer):
 
                 for key_point in key_points:
                     key_point_li = soup.new_tag("li")
-                    key_point_li.string = key_point
+                    self.render_markdown_inline(key_point_li, key_point)
                     key_points_ul.append(key_point_li)
 
                 key_points_div.append(key_points_ul)
@@ -296,7 +303,7 @@ class MeetingPrepRenderer(BaseRenderer):
 
                 for question in questions:
                     question_li = soup.new_tag("li")
-                    question_li.string = question
+                    self.render_markdown_inline(question_li, question)
                     questions_ul.append(question_li)
 
                 questions_div.append(questions_ul)
@@ -331,7 +338,8 @@ class MeetingPrepRenderer(BaseRenderer):
             # Area as heading
             area = reco.get("area", "")
             reco_h4 = soup.new_tag("h4")
-            reco_h4.string = f"{i + 1}. {area}"
+            reco_h4.append(f"{i + 1}. ")
+            self.render_markdown_inline(reco_h4, area)
             reco_div.append(reco_h4)
 
             # Suggestion
@@ -344,7 +352,8 @@ class MeetingPrepRenderer(BaseRenderer):
                 strong = soup.new_tag("strong")
                 strong.string = "Suggestion:"
                 suggestion_p.append(strong)
-                suggestion_p.append(f" {suggestion}")
+                suggestion_p.append(" ")
+                self.render_markdown_inline(suggestion_p, suggestion)
                 suggestion_div.append(suggestion_p)
 
                 reco_div.append(suggestion_div)
@@ -359,7 +368,8 @@ class MeetingPrepRenderer(BaseRenderer):
                 strong = soup.new_tag("strong")
                 strong.string = "Résultat attendu:"
                 outcome_p.append(strong)
-                outcome_p.append(f" {expected_outcome}")
+                outcome_p.append(" ")
+                self.render_markdown_inline(outcome_p, expected_outcome)
                 outcome_div.append(outcome_p)
 
                 reco_div.append(outcome_div)
@@ -398,17 +408,17 @@ class MeetingPrepRenderer(BaseRenderer):
             if url:
                 # Create clickable title
                 title_a = soup.new_tag("a", href=url, target="_blank")
-                title_a.string = title
+                self.render_markdown_inline(title_a, title)
                 resource_h4.append(title_a)
             else:
-                resource_h4.string = title
+                self.render_markdown_inline(resource_h4, title)
             resource_div.append(resource_h4)
 
             # Description
             description = resource.get("description", "")
             if description:
                 desc_p = soup.new_tag("p")
-                desc_p.string = description
+                self.render_markdown_inline(desc_p, description)
                 resource_div.append(desc_p)
 
             # Display URL separately if available

--- a/src/epic_news/utils/html/template_renderers/menu_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/menu_renderer.py
@@ -57,10 +57,11 @@ class MenuRenderer(BaseRenderer):
         # Title
         title = data.get("title", "Menu Hebdomadaire")
         title_tag = soup.new_tag("h1", attrs={"class": "menu-title"})
-        title_tag.string = f"🍽️ {title}"
+        title_tag.append("🍽️ ")
+        self.append_prose(title_tag, title)
         header.append(title_tag)
 
-        # Date range if available
+        # Date range if available (formatted date, not agent prose)
         date_range = data.get("date_range", "")
         if date_range:
             date_tag = soup.new_tag("p", attrs={"class": "menu-date-range"})
@@ -71,7 +72,7 @@ class MenuRenderer(BaseRenderer):
         description = data.get("description", "")
         if description:
             desc_tag = soup.new_tag("p", attrs={"class": "menu-description"})
-            desc_tag.string = description
+            self.append_prose(desc_tag, description)
             header.append(desc_tag)
 
         container.append(header)
@@ -88,9 +89,7 @@ class MenuRenderer(BaseRenderer):
         overview_title.string = "📋 Aperçu de la semaine"
         overview_div.append(overview_title)
 
-        overview_p = soup.new_tag("p")
-        overview_p.string = overview
-        overview_div.append(overview_p)
+        self.render_markdown_block(overview_div, overview)
 
         container.append(overview_div)
 
@@ -102,7 +101,7 @@ class MenuRenderer(BaseRenderer):
             content = data.get("content", "")
             if content:
                 content_div = soup.new_tag("div", attrs={"class": "menu-content"})
-                content_div.string = content
+                self.render_markdown_block(content_div, content)
                 container.append(content_div)
             return
 
@@ -190,7 +189,7 @@ class MenuRenderer(BaseRenderer):
                     dishes_list = soup.new_tag("ul", attrs={"class": "dishes-list"})
                     for dish in meal_content:
                         dish_item = soup.new_tag("li", attrs={"class": "dish-item"})
-                        dish_item.string = dish
+                        self.append_prose(dish_item, dish)
                         dishes_list.append(dish_item)
                     meal_div.append(dishes_list)
                 else:
@@ -220,7 +219,8 @@ class MenuRenderer(BaseRenderer):
                                     emoji = dish_type_emojis.get(dish_type, "🍽️")
                                     # Capitalize dish type for display
                                     display_type = dish_type.capitalize() if dish_type else "Plat"
-                                    dish_li.string = f"{emoji} {display_type}: {dish_name}"
+                                    dish_li.append(f"{emoji} {display_type}: ")
+                                    self.append_prose(dish_li, dish_name)
                                     dishes_list.append(dish_li)
 
                         meal_div.append(dishes_list)
@@ -244,13 +244,14 @@ class MenuRenderer(BaseRenderer):
                                 dish_name = sub_val.get("name") or str(sub_val)
                             else:
                                 dish_name = str(sub_val)
-                            dish_li.string = f"{label}: {dish_name}"
+                            dish_li.append(f"{label}: ")
+                            self.append_prose(dish_li, dish_name)
                             sub_dishes_ul.append(dish_li)
                         meal_div.append(sub_dishes_ul)
                     else:
                         # Single dish or text description
                         meal_text = soup.new_tag("p", attrs={"class": "meal-text"})
-                        meal_text.string = str(meal_content)
+                        self.append_prose(meal_text, meal_content)
                         meal_div.append(meal_text)
 
                 meals_div.append(meal_div)
@@ -259,13 +260,13 @@ class MenuRenderer(BaseRenderer):
             dishes_list = soup.new_tag("ul", attrs={"class": "dishes-list"})
             for meal in meals:
                 dish_item = soup.new_tag("li", attrs={"class": "dish-item"})
-                dish_item.string = meal
+                self.append_prose(dish_item, meal)
                 dishes_list.append(dish_item)
             meals_div.append(dishes_list)
         else:
             # Plain text content
             meal_text = soup.new_tag("p", attrs={"class": "meal-text"})
-            meal_text.string = str(meals)
+            self.append_prose(meal_text, meals)
             meals_div.append(meal_text)
 
         day_div.append(meals_div)
@@ -295,7 +296,7 @@ class MenuRenderer(BaseRenderer):
                 items_list = soup.new_tag("ul")
                 for item in items:
                     item_li = soup.new_tag("li")
-                    item_li.string = item
+                    self.append_prose(item_li, item)
                     items_list.append(item_li)
 
                 category_div.append(items_list)
@@ -305,7 +306,7 @@ class MenuRenderer(BaseRenderer):
             items_list = soup.new_tag("ul")
             for item in shopping_list:
                 item_li = soup.new_tag("li")
-                item_li.string = item
+                self.append_prose(item_li, item)
                 items_list.append(item_li)
 
             shopping_section.append(items_list)
@@ -353,7 +354,7 @@ class MenuRenderer(BaseRenderer):
                 tr.append(td_nutrient)
 
                 td_value = soup.new_tag("td")
-                td_value.string = str(value)
+                self.append_prose(td_value, value)
                 tr.append(td_value)
 
                 tbody.append(tr)
@@ -363,7 +364,7 @@ class MenuRenderer(BaseRenderer):
         else:
             # Simple text information
             nutrition_p = soup.new_tag("p")
-            nutrition_p.string = str(nutrition)
+            self.append_prose(nutrition_p, nutrition)
             nutrition_section.append(nutrition_p)
 
         container.append(nutrition_section)

--- a/src/epic_news/utils/html/template_renderers/osint_global_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/osint_global_renderer.py
@@ -69,15 +69,14 @@ class OSINTGlobalRenderer(BaseRenderer):
 
         return str(soup)
 
-    @staticmethod
-    def _add_header(soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
+    def _add_header(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         header = soup.new_tag("div", **{"class": "report-header"})  # type: ignore[arg-type]
         title = soup.new_tag("h1")
         title.string = "Rapport OSINT Complet"
         header.append(title)
         if company := data.get("company_name"):
             subtitle = soup.new_tag("h2")
-            subtitle.string = company
+            self.append_prose(subtitle, company)
             header.append(subtitle)
         container.append(header)
 
@@ -117,8 +116,7 @@ class OSINTGlobalRenderer(BaseRenderer):
         toc.append(ul)
         container.append(toc)
 
-    @staticmethod
-    def _add_executive_summary(soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
+    def _add_executive_summary(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         section = soup.new_tag("section", **{"class": "report-section", "id": "executive-summary"})  # type: ignore[arg-type]
         title = soup.new_tag("h2")
         title.string = "Resume Executif"
@@ -144,7 +142,7 @@ class OSINTGlobalRenderer(BaseRenderer):
             strong = soup.new_tag("strong")
             strong.string = "Entreprise: "
             p.append(strong)
-            p.append(company)
+            self.append_prose(p, company)
             summary_div.append(p)
 
         # Report count

--- a/src/epic_news/utils/html/template_renderers/pestel_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/pestel_renderer.py
@@ -94,12 +94,7 @@ class PestelRenderer(BaseRenderer):
 
         topic = data.get("topic") or "Subject"
         generated_at = data.get("generated_at") or ""
-        self.add_report_header(
-            soup,
-            container,
-            f"PESTEL Analysis — {topic}",
-            subtitle=f"Generated: {generated_at}" if generated_at else None,
-        )
+        self._add_report_header(soup, container, topic, generated_at)
 
         self.render_text_section(
             soup,
@@ -124,6 +119,19 @@ class PestelRenderer(BaseRenderer):
 
         return str(soup)
 
+    def _add_report_header(self, soup: BeautifulSoup, container: Any, topic: str, generated_at: str) -> None:
+        """Like ``add_report_header``, but renders ``topic`` (agent-authored) as Markdown."""
+        header = soup.new_tag("div", **{"class": "report-header"})  # type: ignore[arg-type]
+        h1 = soup.new_tag("h1")
+        h1.append("PESTEL Analysis — ")
+        self.render_markdown_inline(h1, topic)
+        header.append(h1)
+        if generated_at:
+            h2 = soup.new_tag("h2")
+            h2.string = f"Generated: {generated_at}"
+            header.append(h2)
+        container.append(header)
+
     def _render_dimension(
         self,
         soup: BeautifulSoup,
@@ -141,7 +149,7 @@ class PestelRenderer(BaseRenderer):
             strong = soup.new_tag("strong")
             strong.string = "Summary: "
             p.append(strong)
-            p.append(summary)
+            self.append_prose(p, summary)
             section.append(p)
 
         factors = dim.get("key_factors") or []
@@ -152,7 +160,7 @@ class PestelRenderer(BaseRenderer):
             ul = soup.new_tag("ul")
             for factor in factors:
                 li = soup.new_tag("li")
-                li.string = str(factor)
+                self.append_prose(li, factor)
                 ul.append(li)
             section.append(ul)
         else:
@@ -214,7 +222,7 @@ class PestelRenderer(BaseRenderer):
                 # Render the prefix text, then the link
                 prefix = src_text[: url_match.start()].rstrip(" ,:")
                 if prefix:
-                    li.append(prefix + " ")
+                    self.render_markdown_inline(li, prefix + " ")
                 a = soup.new_tag("a", href=url)
                 a.string = url
                 a.attrs["target"] = "_blank"
@@ -222,9 +230,9 @@ class PestelRenderer(BaseRenderer):
                 li.append(a)
                 suffix = src_text[url_match.start() + len(url_match.group(0)) :]
                 if suffix:
-                    li.append(suffix)
+                    self.render_markdown_inline(li, suffix)
             else:
-                li.string = src_text
+                self.append_prose(li, src_text)
             ul.append(li)
         details.append(ul)
         section.append(details)

--- a/src/epic_news/utils/html/template_renderers/rss_weekly_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/rss_weekly_renderer.py
@@ -65,7 +65,8 @@ class RssWeeklyRenderer(BaseRenderer):
             digest_section.attrs["class"] = ["feed-digest"]  # type: ignore[assignment]
 
             feed_title = soup.new_tag("h3")
-            feed_title.string = f"📡 {feed_name}"
+            feed_title.append("📡 ")
+            self.append_prose(feed_title, feed_name)
             digest_section.append(feed_title)
 
             if feed_url:
@@ -100,7 +101,8 @@ class RssWeeklyRenderer(BaseRenderer):
         title = data.get("title", "RSS Weekly")
         title_tag = soup.new_tag("h1")
         title_tag.attrs["class"] = ["rss-title"]  # type: ignore[assignment]
-        title_tag.string = f"📰 {title}"
+        title_tag.append("📰 ")
+        self.append_prose(title_tag, title)
         header.append(title_tag)
 
         # Date if available
@@ -126,9 +128,7 @@ class RssWeeklyRenderer(BaseRenderer):
         summary_title.string = "📋 Résumé de la semaine"
         summary_div.append(summary_title)
 
-        summary_p = soup.new_tag("p")
-        summary_p.string = summary
-        summary_div.append(summary_p)
+        self.render_markdown_block(summary_div, summary)
 
         container.append(summary_div)
 
@@ -197,10 +197,10 @@ class RssWeeklyRenderer(BaseRenderer):
             link_tag = soup.new_tag("a", href=url)
             link_tag["target"] = "_blank"
             link_tag["rel"] = "noopener noreferrer"
-            link_tag.string = title
+            self.append_prose(link_tag, title)
             title_tag.append(link_tag)
         else:
-            title_tag.string = title
+            self.append_prose(title_tag, title)
         article_div.append(title_tag)
 
         # Published date (canonical "published" or legacy "date")
@@ -225,7 +225,7 @@ class RssWeeklyRenderer(BaseRenderer):
         if description:
             desc_p = soup.new_tag("p")
             desc_p.attrs["class"] = ["article-description"]  # type: ignore[assignment]
-            desc_p.string = description
+            self.append_prose(desc_p, description)
             article_div.append(desc_p)
 
         summary = article.get("summary") or article.get("content") or ""
@@ -270,10 +270,10 @@ class RssWeeklyRenderer(BaseRenderer):
                     link_tag = soup.new_tag("a", href=source_url)
                     link_tag["target"] = "_blank"
                     link_tag["rel"] = "noopener noreferrer"
-                    link_tag.string = source_name
+                    self.append_prose(link_tag, source_name)
                     source_item.append(link_tag)
                 else:
-                    source_item.string = source_name
+                    self.append_prose(source_item, source_name)
 
                 sources_list.append(source_item)
 

--- a/src/epic_news/utils/html/template_renderers/saint_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/saint_renderer.py
@@ -66,14 +66,15 @@ class SaintRenderer(BaseRenderer):
 
         name = data.get("saint_name") or data.get("name") or "Saint"
         title_tag = soup.new_tag("h2")
-        title_tag.string = f"✨ {name}"
+        title_tag.append("✨ ")
+        self.append_prose(title_tag, name)
         header_div.append(title_tag)
 
         # Add subtitle if available
         title = data.get("title") or data.get("epithet")
         if title:
             subtitle_p = soup.new_tag("p", attrs={"class": "saint-title"})
-            subtitle_p.string = title
+            self.append_prose(subtitle_p, title)
             header_div.append(subtitle_p)
 
         container.append(header_div)
@@ -90,9 +91,7 @@ class SaintRenderer(BaseRenderer):
         title_tag.string = "📖 Biographie"
         bio_div.append(title_tag)
 
-        bio_p = soup.new_tag("p")
-        bio_p.string = biography
-        bio_div.append(bio_p)
+        self.render_markdown_block(bio_div, biography)
 
         container.append(bio_div)
 
@@ -187,14 +186,12 @@ class SaintRenderer(BaseRenderer):
         miracles_div.append(title_tag)
 
         if isinstance(miracles, str):
-            miracles_p = soup.new_tag("p")
-            miracles_p.string = miracles
-            miracles_div.append(miracles_p)
+            self.render_markdown_block(miracles_div, miracles)
         elif isinstance(miracles, list):
             miracles_ul = soup.new_tag("ul")
             for item in miracles:
                 li = soup.new_tag("li")
-                li.string = str(item)
+                self.append_prose(li, item)
                 miracles_ul.append(li)
             miracles_div.append(miracles_ul)
 
@@ -212,9 +209,7 @@ class SaintRenderer(BaseRenderer):
         title_tag.string = "🇨🇭 Lien avec la Suisse"
         swiss_div.append(title_tag)
 
-        swiss_p = soup.new_tag("p")
-        swiss_p.string = swiss_connection
-        swiss_div.append(swiss_p)
+        self.render_markdown_block(swiss_div, swiss_connection)
 
         container.append(swiss_div)
 
@@ -236,14 +231,12 @@ class SaintRenderer(BaseRenderer):
         spiritual_div.append(title_tag)
 
         if isinstance(significance, str):
-            spiritual_p = soup.new_tag("p")
-            spiritual_p.string = significance
-            spiritual_div.append(spiritual_p)
+            self.render_markdown_block(spiritual_div, significance)
         elif isinstance(significance, list):
             spiritual_ul = soup.new_tag("ul")
             for item in significance:
                 li = soup.new_tag("li")
-                li.string = str(item)
+                self.append_prose(li, item)
                 spiritual_ul.append(li)
             spiritual_div.append(spiritual_ul)
 
@@ -261,9 +254,7 @@ class SaintRenderer(BaseRenderer):
         title_tag.string = "📿 Prière et Réflexion"
         prayer_div.append(title_tag)
 
-        prayer_p = soup.new_tag("p")
-        prayer_p.string = prayer
-        prayer_div.append(prayer_p)
+        self.render_markdown_block(prayer_div, prayer)
 
         container.append(prayer_div)
 
@@ -282,7 +273,7 @@ class SaintRenderer(BaseRenderer):
         sources_ul = soup.new_tag("ul")
         for source in sources:
             li = soup.new_tag("li")
-            li.string = source
+            self.append_prose(li, source)
             sources_ul.append(li)
         sources_div.append(sources_ul)
 

--- a/src/epic_news/utils/html/template_renderers/shopping_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/shopping_renderer.py
@@ -64,15 +64,14 @@ class ShoppingRenderer(BaseRenderer):
 
         return str(soup)
 
-    @staticmethod
-    def _bullet_list(soup: BeautifulSoup, items: Any, css_class: str | None = None):
+    def _bullet_list(self, soup: BeautifulSoup, items: Any, css_class: str | None = None):
         """Build a ``<ul>`` from a list of scalars, or return None if empty."""
         if not (isinstance(items, list) and items):
             return None
         ul = soup.new_tag("ul", attrs={"class": css_class}) if css_class else soup.new_tag("ul")
         for item in items:
             li = soup.new_tag("li")
-            li.string = str(item)
+            self.append_prose(li, item)
             ul.append(li)
         return ul
 
@@ -91,12 +90,13 @@ class ShoppingRenderer(BaseRenderer):
 
         if name:
             title_tag = soup.new_tag("h2")
-            title_tag.string = f"🛍️ {name}"
+            title_tag.append("🛍️ ")
+            self.append_prose(title_tag, name)
             section.append(title_tag)
 
         if overview:
             overview_p = soup.new_tag("p")
-            overview_p.string = overview
+            self.append_prose(overview_p, overview)
             section.append(overview_p)
 
         target_audience = product.get("target_audience")
@@ -105,7 +105,7 @@ class ShoppingRenderer(BaseRenderer):
             aud_strong = soup.new_tag("strong")
             aud_strong.string = "Public cible : "
             aud_p.append(aud_strong)
-            aud_p.append(soup.new_string(target_audience))
+            self.append_prose(aud_p, target_audience)
             section.append(aud_p)
 
         specs = self._bullet_list(soup, product.get("key_specifications"), "product-specs")
@@ -135,7 +135,7 @@ class ShoppingRenderer(BaseRenderer):
         title_tag.string = "📝 Résumé"
         section.append(title_tag)
         summary_p = soup.new_tag("p")
-        summary_p.string = summary
+        self.append_prose(summary_p, summary)
         section.append(summary_p)
         container.append(section)
 
@@ -197,10 +197,14 @@ class ShoppingRenderer(BaseRenderer):
                 retailer_td.string = retailer
             row.append(retailer_td)
 
-            for key in ("price", "shipping_cost", "total_cost", "notes"):
+            for key in ("price", "shipping_cost", "total_cost"):
                 cell = soup.new_tag("td")
                 cell.string = str(price_item.get(key) or "")
                 row.append(cell)
+
+            notes_cell = soup.new_tag("td")
+            self.append_prose(notes_cell, price_item.get("notes") or "")
+            row.append(notes_cell)
 
             tbody.append(row)
         table.append(tbody)
@@ -265,7 +269,9 @@ class ShoppingRenderer(BaseRenderer):
             price_range = comp.get("price_range")
             if name:
                 heading = soup.new_tag("h4")
-                heading.string = f"{name} ({price_range})" if price_range else name
+                self.append_prose(heading, name)
+                if price_range:
+                    heading.append(f" ({price_range})")
                 card.append(heading)
 
             features = self._bullet_list(soup, comp.get("key_features"))
@@ -278,7 +284,7 @@ class ShoppingRenderer(BaseRenderer):
                 aud_strong = soup.new_tag("strong")
                 aud_strong.string = "Public cible : "
                 aud_p.append(aud_strong)
-                aud_p.append(soup.new_string(target_audience))
+                self.append_prose(aud_p, target_audience)
                 card.append(aud_p)
 
             section.append(card)
@@ -311,7 +317,7 @@ class ShoppingRenderer(BaseRenderer):
 
         content_div = soup.new_tag("div", attrs={"class": "recommendation-content"})
         rec_p = soup.new_tag("p")
-        rec_p.string = recommendation
+        self.append_prose(rec_p, recommendation)
         content_div.append(rec_p)
         section.append(content_div)
         container.append(section)
@@ -327,6 +333,6 @@ class ShoppingRenderer(BaseRenderer):
         title_tag.string = "👤 Contexte pris en compte"
         section.append(title_tag)
         context_p = soup.new_tag("p")
-        context_p.string = context
+        self.append_prose(context_p, context)
         section.append(context_p)
         container.append(section)

--- a/src/epic_news/utils/html/template_renderers/tech_stack_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/tech_stack_renderer.py
@@ -35,7 +35,7 @@ class TechStackRenderer(BaseRenderer):
         soup = self.create_soup("div", class_="tech-stack-report")
         container = soup.div
 
-        self.add_report_header(
+        self._add_report_header(
             soup, container, "🔧 Analyse de la Stack Technologique", data.get("company_name")
         )
         self.render_text_section(soup, container, data.get("executive_summary"), "Résumé Exécutif", "📋")
@@ -49,6 +49,20 @@ class TechStackRenderer(BaseRenderer):
         self.add_raw_json_section(soup, container, data, "Voir les données brutes")
 
         return str(soup)
+
+    def _add_report_header(
+        self, soup: BeautifulSoup, container: Any, title: str, subtitle: str | None
+    ) -> None:
+        """Like ``add_report_header``, but renders ``subtitle`` (agent-authored company name) as Markdown."""
+        header = soup.new_tag("div", **{"class": "report-header"})  # type: ignore[arg-type]
+        h1 = soup.new_tag("h1")
+        h1.string = title
+        header.append(h1)
+        if subtitle:
+            h2 = soup.new_tag("h2")
+            self.render_markdown_inline(h2, subtitle)
+            header.append(h2)
+        container.append(header)
 
     def _add_technology_stack(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         """Render technology stack grouped by category."""
@@ -76,11 +90,11 @@ class TechStackRenderer(BaseRenderer):
             for tech in techs:
                 card = soup.new_tag("div", **{"class": "tech-card"})  # type: ignore[arg-type]
                 name = soup.new_tag("h4")
-                name.string = tech.get("name", "N/A")
+                self.render_markdown_inline(name, tech.get("name", "N/A"))
                 card.append(name)
                 if desc := tech.get("description"):
                     desc_p = soup.new_tag("p")
-                    desc_p.string = desc
+                    self.render_markdown_inline(desc_p, desc)
                     card.append(desc_p)
                 grid.append(card)
             cat_div.append(grid)
@@ -106,7 +120,7 @@ class TechStackRenderer(BaseRenderer):
             ul = soup.new_tag("ul")
             for s in strengths:
                 li = soup.new_tag("li")
-                li.string = s
+                self.render_markdown_inline(li, s)
                 ul.append(li)
             str_div.append(ul)
             grid.append(str_div)
@@ -119,7 +133,7 @@ class TechStackRenderer(BaseRenderer):
             ul = soup.new_tag("ul")
             for w in weaknesses:
                 li = soup.new_tag("li")
-                li.string = w
+                self.render_markdown_inline(li, w)
                 ul.append(li)
             weak_div.append(ul)
             grid.append(weak_div)
@@ -137,7 +151,7 @@ class TechStackRenderer(BaseRenderer):
         ul = soup.new_tag("ul")
         for item in oss:
             li = soup.new_tag("li")
-            li.string = item
+            self.render_markdown_inline(li, item)
             ul.append(li)
         section.append(ul)
         container.append(section)
@@ -152,7 +166,7 @@ class TechStackRenderer(BaseRenderer):
         ul = soup.new_tag("ul", **{"class": "recommendations-list"})  # type: ignore[arg-type]
         for rec in recs:
             li = soup.new_tag("li")
-            li.string = rec
+            self.render_markdown_inline(li, rec)
             ul.append(li)
         section.append(ul)
         container.append(section)

--- a/src/epic_news/utils/html/template_renderers/web_presence_renderer.py
+++ b/src/epic_news/utils/html/template_renderers/web_presence_renderer.py
@@ -35,7 +35,7 @@ class WebPresenceRenderer(BaseRenderer):
         soup = self.create_soup("div", class_="web-presence-report")
         container = soup.div
 
-        self.add_report_header(soup, container, "🌐 Analyse de Présence Web", data.get("company_name"))
+        self._add_report_header(soup, container, "🌐 Analyse de Présence Web", data.get("company_name"))
         self.render_text_section(soup, container, data.get("executive_summary"), "Résumé Exécutif", "📋")
         self._add_website_analysis(soup, container, data)
         self._add_social_media(soup, container, data)
@@ -45,6 +45,20 @@ class WebPresenceRenderer(BaseRenderer):
         self.add_raw_json_section(soup, container, data, "Voir les données brutes")
 
         return str(soup)
+
+    def _add_report_header(
+        self, soup: BeautifulSoup, container: Any, title: str, subtitle: str | None
+    ) -> None:
+        """Like ``add_report_header``, but renders ``subtitle`` (agent-authored company name) as Markdown."""
+        header = soup.new_tag("div", **{"class": "report-header"})  # type: ignore[arg-type]
+        h1 = soup.new_tag("h1")
+        h1.string = title
+        header.append(h1)
+        if subtitle:
+            h2 = soup.new_tag("h2")
+            self.render_markdown_inline(h2, subtitle)
+            header.append(h2)
+        container.append(header)
 
     def _add_website_analysis(self, soup: BeautifulSoup, container: Any, data: dict[str, Any]) -> None:
         """Render website analysis section."""
@@ -70,7 +84,7 @@ class WebPresenceRenderer(BaseRenderer):
                 strong = soup.new_tag("strong")
                 strong.string = f"{label}: "
                 p.append(strong)
-                p.append(value)
+                self.render_markdown_inline(p, value)
                 card.append(p)
 
         if recs := website.get("recommendations", []):
@@ -81,7 +95,7 @@ class WebPresenceRenderer(BaseRenderer):
             ul = soup.new_tag("ul")
             for rec in recs:
                 li = soup.new_tag("li")
-                li.string = rec
+                self.render_markdown_inline(li, rec)
                 ul.append(li)
             recs_div.append(ul)
             card.append(recs_div)
@@ -127,7 +141,7 @@ class WebPresenceRenderer(BaseRenderer):
 
             if notes := social.get("notes"):
                 notes_p = soup.new_tag("p", **{"class": "notes"})  # type: ignore[arg-type]
-                notes_p.string = notes
+                self.render_markdown_inline(notes_p, notes)
                 card.append(notes_p)
 
             grid.append(card)
@@ -179,7 +193,7 @@ class WebPresenceRenderer(BaseRenderer):
 
             header = soup.new_tag("div", **{"class": "leak-header"})  # type: ignore[arg-type]
             source = soup.new_tag("h4")
-            source.string = leak.get("source", "N/A")
+            self.render_markdown_inline(source, leak.get("source", "N/A"))
             header.append(source)
             if date := leak.get("date"):
                 date_span = soup.new_tag("span")
@@ -189,7 +203,7 @@ class WebPresenceRenderer(BaseRenderer):
 
             if desc := leak.get("description"):
                 desc_p = soup.new_tag("p")
-                desc_p.string = desc
+                self.render_markdown_inline(desc_p, desc)
                 card.append(desc_p)
 
             risk_badge = soup.new_tag("span", **{"class": f"risk-badge risk-{risk}"})  # type: ignore[arg-type]
@@ -212,7 +226,7 @@ class WebPresenceRenderer(BaseRenderer):
             card = soup.new_tag("div", **{"class": "competitor-card"})  # type: ignore[arg-type]
 
             header = soup.new_tag("h3")
-            header.string = comp.get("competitor_name", "N/A")
+            self.render_markdown_inline(header, comp.get("competitor_name", "N/A"))
             card.append(header)
 
             if website := comp.get("website"):
@@ -231,7 +245,7 @@ class WebPresenceRenderer(BaseRenderer):
                 ul = soup.new_tag("ul")
                 for s in strengths:
                     li = soup.new_tag("li")
-                    li.string = s
+                    self.render_markdown_inline(li, s)
                     ul.append(li)
                 str_div.append(ul)
                 grid.append(str_div)
@@ -244,7 +258,7 @@ class WebPresenceRenderer(BaseRenderer):
                 ul = soup.new_tag("ul")
                 for w in weaknesses:
                     li = soup.new_tag("li")
-                    li.string = w
+                    self.render_markdown_inline(li, w)
                     ul.append(li)
                 weak_div.append(ul)
                 grid.append(weak_div)

--- a/tests/rendering/test_all_renderers_markdown_contract.py
+++ b/tests/rendering/test_all_renderers_markdown_contract.py
@@ -1,0 +1,181 @@
+"""Every renderer must render agent Markdown, and none may emit live HTML.
+
+Crews return structured JSON (`output_pydantic`), but the LLM writes Markdown *inside*
+the JSON string fields. A renderer that assigns those strings with `tag.string = ...`
+escapes them, shipping literal `**bold**` to the reader. This was fixed across the
+renderer suite; these tests keep it fixed.
+
+Rendering agent text as markup is a security boundary: markdown-it runs with
+`html=False`, so raw HTML in agent output must stay escaped, never become a live tag.
+
+POEM is deliberately excluded: whitespace and literal characters are the content of a
+poem, so its lines must not be reinterpreted as Markdown.
+"""
+
+import re
+
+import pytest
+
+from epic_news.utils.html.template_renderers.renderer_factory import RendererFactory
+
+MD = "**bold**"
+
+# Whitespace-significant output; must keep escaping its content.
+LITERAL_BY_DESIGN = {"POEM"}
+
+XSS_PAYLOADS = [
+    "<script>alert(1)</script>",
+    "<SCRIPT>alert(1)</SCRIPT>",
+    "<img src=x onerror=alert(1)>",
+    "<ImG SrC=x OnErRoR=alert(1)>",
+    "<iframe src='evil'></iframe>",
+    "<svg onload=alert(1)>",
+    "[x](javascript:alert(1))",
+]
+
+
+def _payload() -> dict:
+    """A superset of the field names the renderers look for, every string carrying Markdown."""
+    leaf = f"Texte {MD} ici"
+    item = {
+        "title": f"T {MD}",
+        "name": f"N {MD}",
+        "description": leaf,
+        "content": leaf,
+        "summary": leaf,
+        "value": leaf,
+        "details": leaf,
+        "text": leaf,
+        "url": "https://example.org",
+    }
+    data: dict = {}
+    for key in [
+        "executive_summary",
+        "summary",
+        "content",
+        "description",
+        "methodology",
+        "conclusion",
+        "overview",
+        "analysis",
+        "introduction",
+        "body",
+        "recommendation",
+        "notes",
+        "context",
+        "poem",
+    ]:
+        data[key] = leaf
+    for key in [
+        "key_findings",
+        "findings",
+        "recommendations",
+        "highlights",
+        "insights",
+        "risks",
+        "sources",
+        "items",
+        "articles",
+        "products",
+        "ingredients",
+        "steps",
+        "stanzas",
+        "tags",
+    ]:
+        data[key] = [leaf, leaf]
+    for key in [
+        "physical_locations",
+        "risk_assessment",
+        "supply_chain_map",
+        "mergers_and_acquisitions_insights",
+        "sections",
+        "research_sections",
+        "results",
+        "companies",
+        "leads",
+        "technologies",
+        "platforms",
+        "social_profiles",
+        "meetings",
+        "recipes",
+        "dishes",
+        "saints",
+        "feeds",
+        "entries",
+        "stocks",
+        "assets",
+    ]:
+        data[key] = [dict(item), dict(item)]
+    for key in ["company_name", "title", "topic", "name", "date", "author"]:
+        data[key] = f"Nom {MD}"
+    data["metrics"] = {"score": leaf, "level": leaf}
+    return data
+
+
+def _visible(html: str) -> str:
+    """Strip the raw-JSON debug block: it shows source data verbatim, so `**` belongs there."""
+    body = re.sub(r"<details.*?</details>", "", html, flags=re.S)
+    return re.sub(r"<pre.*?</pre>", "", body, flags=re.S)
+
+
+def _renderable_crews() -> list[str]:
+    """Crews whose renderer accepts the generic payload shape (others are covered elsewhere)."""
+    ok = []
+    for crew in sorted(set(RendererFactory.get_supported_crew_types())):
+        try:
+            RendererFactory.create_renderer(crew).render(_payload())
+        except Exception:
+            continue
+        ok.append(crew)
+    return ok
+
+
+RENDERABLE = _renderable_crews()
+
+
+def test_the_probe_actually_exercises_the_renderers():
+    """Guard the guard: if the payload stops matching, these tests would vacuously pass."""
+    assert len(RENDERABLE) >= 15, f"payload only reached {len(RENDERABLE)} renderers"
+    assert "POEM" in RENDERABLE, "the negative control must be exercised too"
+
+
+@pytest.mark.parametrize("crew", [c for c in RENDERABLE if c not in LITERAL_BY_DESIGN])
+def test_renderer_does_not_ship_literal_markdown(crew):
+    html = RendererFactory.create_renderer(crew).render(_payload())
+
+    assert "**" not in _visible(html), f"{crew} escaped agent Markdown into the page"
+
+
+@pytest.mark.parametrize("crew", sorted(LITERAL_BY_DESIGN & set(RENDERABLE)))
+def test_poem_keeps_its_text_literal(crew):
+    """Negative control: poetry is whitespace-significant and must not be re-parsed."""
+    html = RendererFactory.create_renderer(crew).render(_payload())
+
+    assert "**" in _visible(html), f"{crew} should render text literally"
+
+
+@pytest.mark.parametrize("payload", XSS_PAYLOADS)
+def test_no_renderer_emits_live_html_from_agent_text(payload):
+    """Markdown rendering must not turn agent output into executable markup."""
+
+    def poison(obj):
+        if isinstance(obj, str):
+            return payload
+        if isinstance(obj, list):
+            return [poison(i) for i in obj]
+        if isinstance(obj, dict):
+            return {k: (v if k == "url" else poison(v)) for k, v in obj.items()}
+        return obj
+
+    offenders = []
+    for crew in RENDERABLE:
+        try:
+            html = RendererFactory.create_renderer(crew).render(poison(_payload()))
+        except Exception:
+            continue
+        if re.search(r"<(script|iframe|svg)[\s>]", html, re.IGNORECASE):
+            offenders.append((crew, "live tag"))
+        elif re.search(r"""<a[^>]+href\s*=\s*["']?\s*javascript:""", html, re.IGNORECASE):
+            offenders.append((crew, "javascript: anchor"))
+
+    assert not offenders, f"injection for {payload!r}: {offenders}"

--- a/tests/rendering/test_template_manager_rendering/test_template_manager_rendering_snapshots_FINDAILY_build_findaily_.html
+++ b/tests/rendering/test_template_manager_rendering/test_template_manager_rendering_snapshots_FINDAILY_build_findaily_.html
@@ -1911,8 +1911,7 @@ a:hover { text-decoration: underline; }
     </div>
     
 
-    <div class="financial-report"><div class="financial-header"><h2>💰 Daily Financial Report</h2><p class="report-date">📅 2025-08-10</p></div><div class="executive-summary"><h3>📋 Résumé Exécutif</h3><p>Les marchés montent légèrement.</p></div><div class="financial-analysis"><h3>🔍 Analyse Détaillée</h3><div class="analysis-section"><h4>Stocks</h4><p>Les actions progressent</p><ul><li>S&amp;P 500 +1.0%</li><li>NASDAQ +1.5%</li></ul></div></div><div class="recommendations"><h3>💡 Recommandations</h3><ul class="recommendations-list"><li>[Stocks] Acheter QQQ
-→ Momentum fort</li></ul></div></div>
+    <div class="financial-report"><div class="financial-header"><h2>💰 Daily Financial Report</h2><p class="report-date">📅 2025-08-10</p></div><div class="executive-summary"><h3>📋 Résumé Exécutif</h3><p>Les marchés montent légèrement.</p></div><div class="financial-analysis"><h3>🔍 Analyse Détaillée</h3><div class="analysis-section"><h4>Stocks</h4><p>Les actions progressent</p><ul><li>S&amp;P 500 +1.0%</li><li>NASDAQ +1.5%</li></ul></div></div><div class="recommendations"><h3>💡 Recommandations</h3><ul class="recommendations-list"><li>[Stocks] Acheter QQQ → Momentum fort</li></ul></div></div>
 
     <div class="footer">
       <p>Ce rapport a été généré automatiquement par Epic News.</p>


### PR DESCRIPTION
Follow-up to #150, which fixed `deep_research`. The same defect affected the rest of the renderer suite.

## The defect

Crews return structured JSON (`output_pydantic`), but the model writes **Markdown inside the JSON string fields**. Renderers assigned those strings with `tag.string = ...`, which escapes them — so readers got literal `**bold**` and `- ` bullets in their HTML reports.

## Most of the fix is in `BaseRenderer`, not the 20 leaf files

- `render_dict_as_cards` / `render_list_as_cards` did `p.append(str(value))`. Fixing those two fixed `geospatial_analysis`, `legal_analysis` and `hr_intelligence` **outright** — they emit no text of their own, they only delegate. Their leak count went 742 → 0 without being touched.
- `render_text_section` defaulted to `as_markdown=False`, while **every single caller** passes agent prose (`executive_summary` and friends). `pestel` was the only one opting in explicitly. The default was simply wrong. The flag stays, so `poem` can opt out.
- New `append_prose()` inline-renders `str` values and stringifies everything else, so numeric/bool card fields keep their old behaviour.

## Deliberately left literal

Not everything that *looks* like a leak is one:

- **`poem`** — whitespace and literal characters are the content of a poem. It's the negative control in the new contract test, which asserts it *keeps* its `**`.
- **The raw-JSON `<details>` block** — it shows source data verbatim; `**` belongs there. My first probe counted these and reported 742 leaks across half the codebase. Trusting that number would have sent agents to "fix" correct code.
- **`deep_research` source titles** — that text sits inside an `<a>`, and the parser has `linkify: true`, so rendering a title containing a bare URL would nest an anchor inside an anchor.
- **Enum-ish metadata** (`source_type`, `confidence_level`) and code-formatted values (prices, tickers, dates, counts).

## Security

Rendering agent text as markup is a boundary, so this is load-bearing. markdown-it runs with `html=False`: `<script>`, `<SCRIPT>`, `<img onerror>`, `<svg onload>` and `<iframe>` all come out escaped, and `[x](javascript:alert(1))` is refused by `validateLink`. A parametrized test asserts **no renderer** emits a live tag or a `javascript:` anchor for any of 7 payloads, including case variants.

`cross_reference_report_renderer` needed care: it builds HTML by f-string concatenation rather than BeautifulSoup, so escaping does all the work. Verified separately — no live tags, no `javascript:` anchor.

## Regression caught during review

`company_profiler`'s acquisitions label had been rewritten from `f"{key}: "` to a title-cased `<strong>`, changing visible text from `cible:` to `Cible:` and breaking `test_company_profiler_renderer`. That was scope creep beyond markdown rendering; reverted, keeping only the value's markdown.

## Verification

`650 passed, 5 skipped`. ruff, mypy clean.

The new contract test is **mutation-tested**: regressing `append_prose` to escape makes 10 renderer tests fail. It also guards itself — `test_the_probe_actually_exercises_the_renderers` fails if the synthetic payload stops reaching the renderers, rather than letting the suite pass vacuously.

Also silences bs4's `MarkupResemblesLocatorWarning`, which fired whenever a prose field was entirely a bare URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent-authored content now supports safe inline and block Markdown formatting across reports, including headings, lists, links, tables, and emphasis.
  * Added a clear empty-state message when no shopping data is available.

* **Bug Fixes**
  * Improved HTML safety by preventing raw HTML and potentially executable content from appearing in rendered reports.
  * Standardized formatting of report fields, sources, recommendations, and metadata.
  * Corrected financial recommendation text spacing and line wrapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->