### PR TITLE
fix(email): send reports deterministically instead of via an LLM agent

### DIFF
--- a/src/epic_news/main.py
+++ b/src/epic_news/main.py
@@ -63,7 +63,6 @@ from epic_news.crews.menu_designer.menu_designer import MenuDesignerCrew
 from epic_news.crews.news_daily.news_daily import NewsDailyCrew
 from epic_news.crews.pestel.pestel_crew import PestelCrew
 from epic_news.crews.poem.poem_crew import PoemCrew
-from epic_news.crews.post.post_crew import PostCrew
 from epic_news.crews.rss_weekly.rss_weekly_crew import RssWeeklyCrew
 from epic_news.crews.saint_daily.saint_daily import SaintDailyCrew
 from epic_news.crews.sales_prospecting.sales_prospecting_crew import SalesProspectingCrew
@@ -95,6 +94,7 @@ from epic_news.services.menu_designer_service import MenuDesignerService
 # Import the normalization utility
 from epic_news.utils.diagnostics import dump_crewai_state, parse_crewai_output
 from epic_news.utils.directory_utils import ensure_output_directories
+from epic_news.utils.email_sender import EmailDeliveryError, send_report_email
 from epic_news.utils.extractors.deep_research import DeepResearchExtractor
 from epic_news.utils.extractors.factory import ContentExtractorFactory
 from epic_news.utils.flow_enforcement import akickoff_flow, kickoff_flow
@@ -1409,7 +1409,7 @@ class ReceptionFlow(Flow[ContentState]):
             email_inputs = prepare_email_params(self.state)
 
             # Drop attachment if the file doesn't exist on disk — better to send
-            # an attachment-less email than have PostCrew fail trying to read it.
+            # an attachment-less email than to fail the whole delivery over it.
             attachment_path = email_inputs.get("attachment_path")
             if attachment_path and not Path(attachment_path).exists():
                 self.logger.warning(
@@ -1430,65 +1430,33 @@ class ReceptionFlow(Flow[ContentState]):
                     "📎 No valid attachment file found. Email will be sent without attachment."
                 )
 
-            # If Composio isn't available, skip email sending gracefully
+            # Delivery is deterministic: the recipient, the report and the MIME type
+            # are all known here. An LLM asked to "send this" substituted the
+            # recipient with the placeholder "[EMAIL]" and still reported success,
+            # so no agent sits between the validated inputs and the Gmail API.
+            body_file = email_inputs.get("output_file")
             try:
-                try:
-                    from composio_crewai import CrewAIProvider
+                html_body = Path(body_file).read_text(encoding="utf-8") if body_file else ""
+            except OSError as e:
+                self.logger.error("❌ Cannot read report {} for email body: {}", body_file, e)
+                self.state.email_sent = False
+                return "send_email"
 
-                    # Attempt to initialize to ensure environment is ready
-                    _ = CrewAIProvider()
-                except Exception as e:
-                    self.logger.error(
-                        "❌ Composio not available; email was NOT sent for this run. Reason: {}",
-                        e,
-                    )
-                    self.state.email_sent = False
-                    return "send_email"
-
-                # Instantiate and kickoff the PostCrew (kickoff-only)
-                post_crew = PostCrew()
-                if not post_crew.can_send():
-                    # A tool-less distributor would still report status="success".
-                    self.logger.error(
-                        "❌ No Composio Gmail send/draft tool available; email NOT sent. "
-                        "Verify COMPOSIO_API_KEY and the Gmail connection in Composio."
-                    )
-                    self.state.email_sent = False
-                    return "send_email"
-
-                email_result = kickoff_flow(post_crew, email_inputs)
-
-                # Parse the structured PostResult to log delivery outcome explicitly.
-                # Only a reported success marks the email as sent; anything else must not
-                # suppress a later retry by claiming delivery.
-                post_result = getattr(email_result, "pydantic", None)
-                if post_result is not None:
-                    if getattr(post_result, "status", "") == "success":
-                        self.logger.info(
-                            "📨 PostResult: status=success recipient={} subject={!r} attachment_sent={}",
-                            post_result.recipient_email,
-                            post_result.subject,
-                            post_result.attachment_sent,
-                        )
-                        self.state.email_sent = True
-                    else:
-                        self.logger.error(
-                            "❌ PostResult: status=failure recipient={} error_message={}",
-                            getattr(post_result, "recipient_email", "?"),
-                            getattr(post_result, "error_message", "(none)"),
-                        )
-                        self.state.email_sent = False
-                else:
-                    raw = getattr(email_result, "raw", "") or ""
-                    self.logger.error(
-                        "❌ PostResult absent — agent did not produce structured output; "
-                        "treating email as NOT sent. raw[:500]={!r}",
-                        raw[:500],
-                    )
-                    self.state.email_sent = False
+            try:
+                send_report_email(
+                    recipient=email_inputs["recipient_email"],
+                    subject=email_inputs["subject"],
+                    html_body=html_body,
+                    attachment_path=email_inputs.get("attachment_path"),
+                )
+            except EmailDeliveryError as e:
+                self.logger.error("❌ Email NOT sent: {}", e)
+                self.state.email_sent = False
             except Exception as e:
                 self.state.email_sent = False
-                self.logger.exception("❌ Error during email sending: {}", e)
+                self.logger.exception("❌ Unexpected error during email sending: {}", e)
+            else:
+                self.state.email_sent = True
         else:
             self.logger.info("📧 Email already sent for this request. Skipping.")
         return "send_email"  # Implicitly returns method name

--- a/src/epic_news/utils/email_sender.py
+++ b/src/epic_news/utils/email_sender.py
@@ -1,0 +1,117 @@
+"""Deterministic email delivery through Composio Gmail.
+
+Sending a report is not a reasoning task: the recipient, the report file and the
+MIME type are all known before any crew starts. Delegating it to an LLM cost a
+production run -- the model replaced the validated recipient with the literal
+string ``[EMAIL]``, rewrote the French article "la" in the body as ``[ADDRESS]``,
+and invented a ``from_email``. Gmail rejected the address and nothing shipped.
+Worse, a tool-less agent still reports ``status="success"``.
+
+This module calls ``GMAIL_SEND_EMAIL`` directly and raises on anything that is
+not a delivery confirmed by the API, so ``email_sent`` can never be a guess.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from composio import Composio
+from loguru import logger
+
+GMAIL_SEND_EMAIL = "GMAIL_SEND_EMAIL"
+
+# Manual tool execution refuses to run without a pinned toolkit version
+# (ToolVersionRequiredError). Overridable so a toolkit bump needs no code change.
+DEFAULT_GMAIL_VERSION = "20260702_01"
+
+
+class EmailDeliveryError(RuntimeError):
+    """Raised when Composio did not confirm delivery."""
+
+
+def _gmail_version() -> str:
+    return os.getenv("COMPOSIO_GMAIL_VERSION", DEFAULT_GMAIL_VERSION)
+
+
+def _upload_root() -> Path:
+    """Directory auto-upload is confined to. Reports live here; secrets do not."""
+    return Path(os.getenv("EPIC_OUTPUT_DIR", "output")).resolve()
+
+
+def build_client(api_key: str | None = None) -> Composio:
+    """Composio client allowed to upload attachments from the output directory.
+
+    Attachments are local paths. Without ``dangerously_allow_auto_upload_download_files``
+    the SDK forwards the path verbatim as an already-uploaded S3 key and Gmail 404s.
+    ``file_upload_dirs`` replaces Composio's default allowlist, so auto-upload can
+    only ever read files we generated.
+    """
+    key = api_key or os.getenv("COMPOSIO_API_KEY")
+    if not key:
+        raise EmailDeliveryError("COMPOSIO_API_KEY is not set; cannot send email.")
+
+    return Composio(
+        api_key=key,
+        dangerously_allow_auto_upload_download_files=True,
+        file_upload_dirs=[str(_upload_root())],
+    )
+
+
+def send_report_email(
+    *,
+    recipient: str,
+    subject: str,
+    html_body: str,
+    attachment_path: str | Path | None = None,
+    user_id: str = "default",
+    client: Any | None = None,
+) -> dict[str, Any]:
+    """Send ``html_body`` to ``recipient``, optionally attaching ``attachment_path``.
+
+    Returns the Composio ``data`` payload on success.
+
+    Raises:
+        EmailDeliveryError: on an invalid recipient, an empty body, a missing
+            attachment, or any response Composio did not mark successful.
+    """
+    if not recipient or "@" not in recipient:
+        raise EmailDeliveryError(f"Refusing to send: {recipient!r} is not a valid email address")
+    if not html_body or not html_body.strip():
+        raise EmailDeliveryError("Refusing to send an empty report body")
+
+    arguments: dict[str, Any] = {
+        "recipient_email": recipient,
+        "subject": subject,
+        "body": html_body,
+        "is_html": True,
+    }
+
+    if attachment_path:
+        attachment = Path(attachment_path).resolve()
+        if not attachment.is_file():
+            raise EmailDeliveryError(f"Attachment does not exist: {attachment}")
+        arguments["attachment"] = str(attachment)
+
+    client = client or build_client()
+    logger.info(
+        "📤 Sending report to {} (attachment={})",
+        recipient,
+        arguments.get("attachment", "none"),
+    )
+
+    response = client.tools.execute(
+        GMAIL_SEND_EMAIL,
+        arguments=arguments,
+        user_id=user_id,
+        version=_gmail_version(),
+    )
+
+    # execute() returns a plain dict, not an object: getattr(response, "successful")
+    # would quietly yield None and turn every delivery into a reported failure.
+    if not response.get("successful"):
+        raise EmailDeliveryError(response.get("error") or "Composio reported failure without an error")
+
+    logger.info("📨 Email delivered to {}", recipient)
+    return response.get("data") or {}

--- a/src/epic_news/utils/report_utils.py
+++ b/src/epic_news/utils/report_utils.py
@@ -1,6 +1,7 @@
 import json
 import os
 import re
+from pathlib import Path
 from typing import Any
 
 from loguru import logger
@@ -110,6 +111,32 @@ def _valid_email(value: Any) -> str | None:
     return value if _EMAIL_RE.match(value) else None
 
 
+def resolve_report_html(output_file: Any) -> str | None:
+    """Return the rendered HTML report matching ``output_file``, if one exists.
+
+    ``state.output_file`` is the crew's *write target* (usually ``report.json``), not
+    the artifact a reader wants. Crews render the HTML alongside it as ``report.html``
+    but never update the state, so the email step used to mail raw JSON as the body
+    and attach that same JSON. Prefer the HTML sibling; fall back to the file itself.
+    """
+    if not isinstance(output_file, str) or not output_file.strip():
+        return None
+
+    path = Path(output_file)
+    if path.suffix.lower() == ".html":
+        return str(path) if path.is_file() else None
+
+    sibling = path.with_suffix(".html")
+    if sibling.is_file():
+        return str(sibling)
+
+    logger.warning(
+        "📄 No rendered HTML report next to {}; the email body will not be HTML.",
+        output_file,
+    )
+    return str(path) if path.is_file() else None
+
+
 def prepare_email_params(state: Any) -> dict[str, Any]:
     """
     Prepares the parameters for sending an email based on the application state.
@@ -141,16 +168,17 @@ def prepare_email_params(state: Any) -> dict[str, Any]:
         recipient = _FALLBACK_RECIPIENT
     subject = f"Epic News Report: {state.selected_crew} - {state.user_request}"
     body = f"Please find the report for '{state.user_request}' attached."
-    attachment_path = getattr(state, "output_file", None)
     output_file = getattr(state, "output_file", None)
+    # Body and attachment are both the rendered report, never the crew's raw JSON.
+    report_html = resolve_report_html(output_file)
     topic = f"{state.selected_crew} - {state.user_request}"
 
     return {
         "recipient_email": recipient,
         "subject": subject,
         "body": body,
-        "attachment_path": attachment_path,
-        "output_file": output_file,
+        "attachment_path": report_html,
+        "output_file": report_html or output_file,
         "topic": topic,
     }
 

--- a/tests/flows/test_send_email_honesty.py
+++ b/tests/flows/test_send_email_honesty.py
@@ -4,107 +4,74 @@ A real run logged `PostResult: status=success` for an email that was never deliv
 Composio returned HTTP 401, the distributor agent ran with zero send tools, and the
 LLM self-reported success. The flow then set email_sent=True regardless of outcome,
 suppressing any retry.
-"""
 
-from types import SimpleNamespace
+A later run failed the opposite way: the agent *had* a working Gmail tool but replaced
+the validated recipient with the literal placeholder "[EMAIL]", so Gmail rejected the
+address. Delivery is now deterministic -- no LLM sits between the validated inputs and
+the Gmail API -- and email_sent reflects only what the API confirmed.
+"""
 
 import pytest
 
 import epic_news.main as main_mod
 from epic_news.main import ReceptionFlow
+from epic_news.utils.email_sender import EmailDeliveryError
+
+BODY = "<html><body>report</body></html>"
 
 
 @pytest.fixture
 def flow(monkeypatch, tmp_path) -> ReceptionFlow:
     monkeypatch.setenv("EPIC_ENABLE_EMAIL", "true")
-    attachment = tmp_path / "report.html"
-    attachment.write_text("<html></html>", encoding="utf-8")
+    report = tmp_path / "report.html"
+    report.write_text(BODY, encoding="utf-8")
 
     f = ReceptionFlow("test request")
     f.state.sendto = "someone@example.com"
-    f.state.output_file = str(attachment)
+    f.state.output_file = str(report)
     f.state.email_sent = False
     return f
 
 
-def _stub_composio_available(monkeypatch):
-    monkeypatch.setattr(main_mod, "CrewAIProvider", object, raising=False)
-
-
-class _FakePostCrew:
-    can_send_result = True
-    kickoff_result: object = None
-
-    def __init__(self):
-        pass
-
-    def can_send(self):
-        return type(self).can_send_result
-
-
-def test_email_not_marked_sent_when_no_send_tools(flow, monkeypatch):
-    """The 401 case: no Gmail tool, so nothing can be delivered."""
-    _FakePostCrew.can_send_result = False
-    monkeypatch.setattr(main_mod, "PostCrew", _FakePostCrew)
-
-    flow.send_email()
-
-    assert flow.state.email_sent is False, "claimed delivery with no send tool"
-
-
-def test_email_marked_sent_only_on_reported_success(flow, monkeypatch):
-    _FakePostCrew.can_send_result = True
-    monkeypatch.setattr(main_mod, "PostCrew", _FakePostCrew)
-    result = SimpleNamespace(
-        pydantic=SimpleNamespace(
-            status="success",
-            recipient_email="someone@example.com",
-            subject="s",
-            attachment_sent=True,
-        )
-    )
-    monkeypatch.setattr(main_mod, "kickoff_flow", lambda crew, inputs: result)
+def test_email_marked_sent_only_on_confirmed_delivery(flow, monkeypatch):
+    monkeypatch.setattr(main_mod, "send_report_email", lambda **_kw: {"id": "abc"})
 
     flow.send_email()
 
     assert flow.state.email_sent is True
 
 
-def test_reported_failure_does_not_mark_sent(flow, monkeypatch):
-    _FakePostCrew.can_send_result = True
-    monkeypatch.setattr(main_mod, "PostCrew", _FakePostCrew)
-    result = SimpleNamespace(
-        pydantic=SimpleNamespace(
-            status="failure", recipient_email="someone@example.com", error_message="smtp down"
-        )
-    )
-    monkeypatch.setattr(main_mod, "kickoff_flow", lambda crew, inputs: result)
+def test_delivery_error_does_not_mark_sent(flow, monkeypatch):
+    """The 401 / no-send-tool / rejected-recipient cases all surface here."""
+
+    def boom(**_kw):
+        raise EmailDeliveryError("Composio reported failure")
+
+    monkeypatch.setattr(main_mod, "send_report_email", boom)
 
     flow.send_email()
 
-    assert flow.state.email_sent is False
+    assert flow.state.email_sent is False, "claimed delivery after a delivery error"
 
 
-def test_missing_structured_output_does_not_mark_sent(flow, monkeypatch):
-    _FakePostCrew.can_send_result = True
-    monkeypatch.setattr(main_mod, "PostCrew", _FakePostCrew)
-    monkeypatch.setattr(
-        main_mod, "kickoff_flow", lambda crew, inputs: SimpleNamespace(pydantic=None, raw="blah")
-    )
-
-    flow.send_email()
-
-    assert flow.state.email_sent is False
-
-
-def test_kickoff_exception_does_not_mark_sent(flow, monkeypatch):
-    _FakePostCrew.can_send_result = True
-    monkeypatch.setattr(main_mod, "PostCrew", _FakePostCrew)
-
-    def boom(crew, inputs):
+def test_unexpected_exception_does_not_mark_sent(flow, monkeypatch):
+    def boom(**_kw):
         raise RuntimeError("provider exploded")
 
-    monkeypatch.setattr(main_mod, "kickoff_flow", boom)
+    monkeypatch.setattr(main_mod, "send_report_email", boom)
+
+    flow.send_email()
+
+    assert flow.state.email_sent is False
+
+
+def test_unreadable_report_does_not_mark_sent(flow, monkeypatch):
+    flow.state.output_file = "/nonexistent/report.html"
+
+    def fail(**_kw):  # pragma: no cover - must not be reached
+        raise AssertionError("must not send when the body cannot be read")
+
+    monkeypatch.setattr(main_mod, "send_report_email", fail)
 
     flow.send_email()
 
@@ -114,11 +81,50 @@ def test_kickoff_exception_does_not_mark_sent(flow, monkeypatch):
 def test_already_sent_is_skipped(flow, monkeypatch):
     flow.state.email_sent = True
 
-    def fail(*_a, **_k):  # pragma: no cover - must not be reached
+    def fail(**_kw):  # pragma: no cover - must not be reached
         raise AssertionError("should not attempt a second send")
 
-    monkeypatch.setattr(main_mod, "PostCrew", fail)
+    monkeypatch.setattr(main_mod, "send_report_email", fail)
 
     flow.send_email()
 
     assert flow.state.email_sent is True
+
+
+def test_disabled_by_env_does_not_send(flow, monkeypatch):
+    monkeypatch.setenv("EPIC_ENABLE_EMAIL", "false")
+
+    def fail(**_kw):  # pragma: no cover - must not be reached
+        raise AssertionError("EPIC_ENABLE_EMAIL=false must not send")
+
+    monkeypatch.setattr(main_mod, "send_report_email", fail)
+
+    flow.send_email()
+
+
+def test_the_real_report_html_is_the_body_and_attachment(flow, monkeypatch):
+    """Regression: the flow used to mail raw JSON as the body and attach it too."""
+    captured = {}
+
+    def capture(**kwargs):
+        captured.update(kwargs)
+        return {}
+
+    monkeypatch.setattr(main_mod, "send_report_email", capture)
+
+    flow.send_email()
+
+    assert captured["html_body"] == BODY
+    assert captured["recipient"] == "someone@example.com"
+    assert str(captured["attachment_path"]).endswith("report.html")
+
+
+def test_recipient_is_never_a_placeholder(flow, monkeypatch):
+    """The model emitted "[EMAIL]"; the flow must pass the address it validated."""
+    captured = {}
+    monkeypatch.setattr(main_mod, "send_report_email", lambda **kw: captured.update(kw) or {})
+
+    flow.send_email()
+
+    assert "@" in captured["recipient"]
+    assert "[" not in captured["recipient"]

--- a/tests/utils/test_email_sender.py
+++ b/tests/utils/test_email_sender.py
@@ -1,0 +1,163 @@
+"""The deterministic Gmail sender must refuse bad input and never fake success.
+
+Every guard here corresponds to a way the previous, agent-driven send actually failed
+in production:
+
+* the model passed the placeholder "[EMAIL]" as the recipient -> Gmail 400;
+* it passed a *local path* as ``attachment``, which Composio reads as an already
+  uploaded S3 key -> 404;
+* a tool-less agent reported ``status="success"`` for a run it never sent.
+
+``tools.execute`` also returns a plain ``dict``. ``getattr(response, "successful")``
+silently yields ``None``, which would turn every real delivery into a reported
+failure -- so the success check must use item access.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from epic_news.utils import email_sender
+from epic_news.utils.email_sender import (
+    GMAIL_SEND_EMAIL,
+    EmailDeliveryError,
+    send_report_email,
+)
+
+
+class FakeTools:
+    def __init__(self, response: dict[str, Any]):
+        self.response = response
+        self.calls: list[dict[str, Any]] = []
+
+    def execute(self, slug: str, arguments: dict, **kwargs):
+        self.calls.append({"slug": slug, "arguments": arguments, **kwargs})
+        return self.response
+
+
+class FakeClient:
+    def __init__(self, response: dict[str, Any]):
+        self.tools = FakeTools(response)
+
+
+def _ok() -> FakeClient:
+    return FakeClient({"successful": True, "error": None, "data": {"id": "msg-1"}})
+
+
+@pytest.fixture
+def report(tmp_path) -> Path:
+    f = tmp_path / "report.html"
+    f.write_text("<html>hi</html>", encoding="utf-8")
+    return f
+
+
+def test_sends_html_with_expected_arguments():
+    client = _ok()
+
+    data = send_report_email(recipient="a@b.com", subject="Subject", html_body="<p>x</p>", client=client)
+
+    assert data == {"id": "msg-1"}
+    call = client.tools.calls[0]
+    assert call["slug"] == GMAIL_SEND_EMAIL
+    assert call["arguments"]["recipient_email"] == "a@b.com"
+    assert call["arguments"]["is_html"] is True
+    assert "attachment" not in call["arguments"], "no attachment must send no attachment key"
+
+
+def test_manual_execution_pins_a_toolkit_version():
+    """Without an explicit version the SDK raises ToolVersionRequiredError."""
+    client = _ok()
+
+    send_report_email(recipient="a@b.com", subject="s", html_body="x", client=client)
+
+    assert client.tools.calls[0]["version"], "version must be passed to tools.execute"
+
+
+@pytest.mark.parametrize("bad", ["[EMAIL]", "", "plainuser", "me"])
+def test_rejects_recipients_without_a_domain(bad):
+    """The exact string the model substituted, plus its neighbours."""
+    client = _ok()
+
+    with pytest.raises(EmailDeliveryError, match="not a valid email"):
+        send_report_email(recipient=bad, subject="s", html_body="x", client=client)
+
+    assert not client.tools.calls, "must not call Gmail with a bad recipient"
+
+
+@pytest.mark.parametrize("empty", ["", "   ", "\n"])
+def test_rejects_empty_body(empty):
+    client = _ok()
+
+    with pytest.raises(EmailDeliveryError, match="empty report body"):
+        send_report_email(recipient="a@b.com", subject="s", html_body=empty, client=client)
+
+    assert not client.tools.calls
+
+
+def test_rejects_missing_attachment(tmp_path):
+    client = _ok()
+
+    with pytest.raises(EmailDeliveryError, match="Attachment does not exist"):
+        send_report_email(
+            recipient="a@b.com",
+            subject="s",
+            html_body="x",
+            attachment_path=tmp_path / "gone.html",
+            client=client,
+        )
+
+    assert not client.tools.calls
+
+
+def test_attachment_is_passed_as_an_absolute_path(report):
+    """Composio auto-uploads a local path only when it resolves inside the allowlist."""
+    client = _ok()
+
+    send_report_email(recipient="a@b.com", subject="s", html_body="x", attachment_path=report, client=client)
+
+    sent = client.tools.calls[0]["arguments"]["attachment"]
+    assert Path(sent).is_absolute()
+    assert Path(sent) == report.resolve()
+
+
+def test_failure_response_raises():
+    client = FakeClient({"successful": False, "error": "Invalid email format", "data": {}})
+
+    with pytest.raises(EmailDeliveryError, match="Invalid email format"):
+        send_report_email(recipient="a@b.com", subject="s", html_body="x", client=client)
+
+
+def test_failure_without_error_message_still_raises():
+    client = FakeClient({"successful": False, "error": None, "data": {}})
+
+    with pytest.raises(EmailDeliveryError, match="without an error"):
+        send_report_email(recipient="a@b.com", subject="s", html_body="x", client=client)
+
+
+def test_success_is_read_by_item_access_not_getattr():
+    """A dict has no ``.successful`` attribute; getattr would yield None -> false failure."""
+    response = {"successful": True, "error": None, "data": {}}
+    assert getattr(response, "successful", None) is None  # the trap
+
+    send_report_email(recipient="a@b.com", subject="s", html_body="x", client=FakeClient(response))
+
+
+def test_build_client_requires_an_api_key(monkeypatch):
+    monkeypatch.delenv("COMPOSIO_API_KEY", raising=False)
+
+    with pytest.raises(EmailDeliveryError, match="COMPOSIO_API_KEY"):
+        email_sender.build_client()
+
+
+def test_build_client_confines_uploads_to_the_output_dir(monkeypatch, tmp_path):
+    """Auto-upload must never be able to read outside our generated reports."""
+    captured = {}
+    monkeypatch.setenv("COMPOSIO_API_KEY", "test-key-not-real")
+    monkeypatch.setenv("EPIC_OUTPUT_DIR", str(tmp_path))
+    monkeypatch.setattr(email_sender, "Composio", lambda **kw: captured.update(kw) or object())
+
+    email_sender.build_client()
+
+    assert captured["dangerously_allow_auto_upload_download_files"] is True
+    assert captured["file_upload_dirs"] == [str(tmp_path.resolve())]

--- a/tests/utils/test_report_html_resolution.py
+++ b/tests/utils/test_report_html_resolution.py
@@ -1,0 +1,66 @@
+"""The email body must be the rendered HTML report, never the crew's raw JSON.
+
+`state.output_file` is the crew's *write target* (`report.json`). Crews render
+`report.html` beside it but never update the state, so the email step used to mail
+raw JSON as the body -- the agent duly reported `html_preserved: false` -- and attach
+that same JSON file.
+"""
+
+from epic_news.utils.report_utils import prepare_email_params, resolve_report_html
+
+
+class _State:
+    selected_crew = "DEEPRESEARCH"
+    user_request = "topic"
+    sendto = "someone@example.com"
+
+    def __init__(self, output_file: str):
+        self.output_file = output_file
+
+
+def test_prefers_the_html_sibling_of_a_json_target(tmp_path):
+    (tmp_path / "report.json").write_text("{}", encoding="utf-8")
+    html = tmp_path / "report.html"
+    html.write_text("<html></html>", encoding="utf-8")
+
+    assert resolve_report_html(str(tmp_path / "report.json")) == str(html)
+
+
+def test_returns_html_target_unchanged(tmp_path):
+    html = tmp_path / "report.html"
+    html.write_text("<html></html>", encoding="utf-8")
+
+    assert resolve_report_html(str(html)) == str(html)
+
+
+def test_falls_back_to_the_json_when_no_html_was_rendered(tmp_path):
+    json_file = tmp_path / "report.json"
+    json_file.write_text("{}", encoding="utf-8")
+
+    assert resolve_report_html(str(json_file)) == str(json_file)
+
+
+def test_missing_html_target_returns_none(tmp_path):
+    assert resolve_report_html(str(tmp_path / "gone.html")) is None
+
+
+def test_missing_everything_returns_none(tmp_path):
+    assert resolve_report_html(str(tmp_path / "gone.json")) is None
+
+
+def test_blank_and_non_string_inputs_return_none():
+    assert resolve_report_html("") is None
+    assert resolve_report_html("   ") is None
+    assert resolve_report_html(None) is None
+
+
+def test_email_params_body_and_attachment_are_the_html_report(tmp_path):
+    (tmp_path / "report.json").write_text('{"a": 1}', encoding="utf-8")
+    html = tmp_path / "report.html"
+    html.write_text("<html></html>", encoding="utf-8")
+
+    params = prepare_email_params(_State(str(tmp_path / "report.json")))
+
+    assert params["output_file"] == str(html), "body must be the HTML report"
+    assert params["attachment_path"] == str(html), "attachment must be the HTML report"
+    assert not params["output_file"].endswith(".json")

--- a/tests/utils/test_report_utils.py
+++ b/tests/utils/test_report_utils.py
@@ -35,7 +35,9 @@ def test_prepare_email_params_defaults(mocker, mock_state):
     assert params["recipient_email"] == _FALLBACK_RECIPIENT
     assert params["subject"] == f"Epic News Report: {mock_state.selected_crew} - {mock_state.user_request}"
     assert params["body"] == f"Please find the report for '{mock_state.user_request}' attached."
-    assert params["attachment_path"] == mock_state.output_file
+    # output_file names a file that was never rendered, so there is nothing to attach.
+    # Handing back a dangling path is what made Composio treat it as an uploaded S3 key.
+    assert params["attachment_path"] is None
     assert params["output_file"] == mock_state.output_file
     assert params["topic"] == f"{mock_state.selected_crew} - {mock_state.user_request}"
 
@@ -44,6 +46,18 @@ def test_prepare_email_params_defaults(mocker, mock_state):
     mock_state.sendto = test_email
     params = prepare_email_params(mock_state)
     assert params["recipient_email"] == test_email
+
+
+def test_prepare_email_params_attaches_a_report_that_exists(mock_state, tmp_path):
+    """When the crew actually rendered the report, it is both body and attachment."""
+    report = tmp_path / "report.html"
+    report.write_text("<html></html>", encoding="utf-8")
+    mock_state.output_file = str(report)
+
+    params = prepare_email_params(mock_state)
+
+    assert params["attachment_path"] == str(report)
+    assert params["output_file"] == str(report)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What the logs showed

The last run reported the email as failed. The flow logged exactly what it handed to `PostCrew`:

```
✉️  Email payload: recipient=fred@ljf.ch  attachment=output/deep_research/report.json
```

A valid address went in. The agent then called `GMAIL_SEND_EMAIL` with `recipient_email: "[EMAIL]"`, invented `from_email: "[ADDRESS]"` (never an input), and rewrote the French article *la* in the body as `[ADDRESS]`. Gmail rejected the address — correctly, `[EMAIL]` has no `@`.

**Nothing in our stack redacts.** No PII library is installed, no hook rewrites output, and a sentinel email printed through the same path came back untouched. Decisively: `la` survived unredacted in the `subject` of the very same tool call it was mangled in the `body` — a regex cannot do that, but a model doing context-dependent entity replacement can. `mistral-small` was anonymising PII it had been asked to use.

## The fix

Delivery is deterministic. The recipient, the report file and the MIME type are all known before any crew starts; the only model-authored value was the subject, which the task template already derives. No agent sits between the validated inputs and the Gmail API.

This also fixes two defects the agent had been masking:

**Attachments could never have worked.** Composio's `attachment` parameter takes `{name, s3key, mimetype}` where `s3key` points at a file *already uploaded to Composio storage*. We passed a local path, so it was looked up as an s3key and 404'd. Auto-upload (`dangerously_allow_auto_upload_download_files`) is off by default; it is now enabled with `file_upload_dirs` confined to the output directory — which doubles as a containment boundary, so auto-upload can only ever read files we generated.

**We emailed the wrong file.** `prepare_email_params` used `state.output_file` for both body and attachment, and that is the crew's JSON *write target*. Crews render `report.html` beside it but never update the state, so the rendered report was never sent and the agent duly reported `html_preserved: false`.

`email_sent` now reflects only a delivery Composio confirmed. Note `tools.execute` returns a plain `dict`: `getattr(response, "successful")` silently yields `None`, which would turn every real delivery into a reported failure — so success is read by item access.

## Verification

- 646 passed, 5 skipped; ruff and mypy clean.
- Mutation-tested: dropping the recipient guard, swapping item access for `getattr`, and restoring the raw-JSON body each make the new tests fail.
- `GMAIL_GET_PROFILE` confirms the Gmail connection is live and that manual `tools.execute` requires a pinned toolkit version (`ToolVersionRequiredError` without one).

## Not covered here

An end-to-end run has not been performed — no real report has been delivered yet. A separate `DeepResearchReport` validation error (`methodology`, `sources_count`, `confidence_level` missing) is unrelated and still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBP4PYfXDbtCS1VjQcfSQ