### PR TITLE
fix(deep_research): stop a single LLM omission from failing the whole run

### DIFF
--- a/src/epic_news/crews/deep_research/config/tasks.yaml
+++ b/src/epic_news/crews/deep_research/config/tasks.yaml
@@ -128,35 +128,32 @@ report_writing_task:
         {
           "section_title": "Titre de section",
           "content": "Contenu détaillé",
-          "conclusions": "Conclusions spécifiques à cette section",
           "sources": [
             {
               "title": "Titre de la source",
               "url": "https://example.com",
               "source_type": "web",
               "summary": "Résumé de la source",
-              "relevance_score": 8,
-              "credibility_score": 0.85,
-              "extraction_date": "2025-07-17"
+              "relevance_score": 8
             }
           ]
         }
       ],
       "methodology": "Méthodologie utilisée",
-      "sources_count": 15,
       "report_date": "2025-07-17",
-      "confidence_level": "High",
-      "conclusions": "Conclusions générales de la recherche"
+      "confidence_level": "High"
     }
     ```
-    IMPORTANT: Le modèle JSON DOIT respecter la structure exacte du modèle DeepResearchReport
-    avec:
-    - Tous les champs obligatoires (title, topic, executive_summary, key_findings,
-    research_sections, methodology, conclusions)
-    - Chaque section de recherche doit avoir un champ "section_title" (PAS "title")
-    et un champ "conclusions"
-    - Chaque source doit obligatoirement avoir une URL valide et un score de crédibilité
-    entre 0 et 1
+    IMPORTANT: Le JSON DOIT respecter EXACTEMENT la structure ci-dessus, sans champ
+    supplémentaire:
+    - Champs de niveau supérieur: title, topic, executive_summary, key_findings,
+    research_sections, methodology, report_date, confidence_level.
+    - Chaque section a UNIQUEMENT: "section_title" (PAS "title"), "content", "sources".
+    - Chaque source a UNIQUEMENT: "title", "url" (valide), "source_type", "summary",
+    "relevance_score" (entier de 1 à 10).
+    - N'inventez PAS de champs "conclusions", "credibility_score" ni "extraction_date":
+    ils ne font pas partie du modèle.
+    - N'écrivez PAS "sources_count": il est calculé automatiquement à partir des sources.
   agent: report_writer
   context:
     - research_planning_task

--- a/src/epic_news/models/crews/deep_research_report.py
+++ b/src/epic_news/models/crews/deep_research_report.py
@@ -1,6 +1,6 @@
 """Pydantic models for structuring deep research report data."""
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ResearchSource(BaseModel):
@@ -18,18 +18,42 @@ class ResearchSection(BaseModel):
 
     section_title: str = Field(..., description="Title of the research section")
     content: str = Field(..., description="Detailed content for this section")
-    sources: list[ResearchSource] = Field(..., description="Sources supporting this section")
+    sources: list[ResearchSource] = Field(default_factory=list, description="Sources supporting this section")
 
 
 class DeepResearchReport(BaseModel):
-    """Comprehensive research report model."""
+    """Comprehensive research report model.
+
+    This is the crew's ``output_pydantic`` contract, so the LLM must produce it in one
+    shot. Fields the model reliably supplies stay required; three that a small model
+    intermittently omitted are made resilient, because a single omission failed the
+    whole (~9-minute) research run via ``output_pydantic`` validation:
+
+    * ``sources_count`` is *computed* from the sections below, never trusted from the
+      LLM -- counting is a deterministic job a model should not be asked to do.
+    * ``methodology`` and ``confidence_level`` default rather than hard-fail; the
+      renderer already treats both as optional.
+    """
 
     title: str = Field(..., description="Main title of the research report")
     topic: str = Field(..., description="Research topic")
     executive_summary: str = Field(..., description="High-level summary of findings")
-    key_findings: list[str] = Field(..., description="List of key discoveries")
-    research_sections: list[ResearchSection] = Field(..., description="Detailed research sections")
-    methodology: str = Field(..., description="Research methodology used")
-    sources_count: int = Field(..., description="Total number of sources consulted")
+    key_findings: list[str] = Field(default_factory=list, description="List of key discoveries")
+    research_sections: list[ResearchSection] = Field(
+        default_factory=list, description="Detailed research sections"
+    )
+    methodology: str = Field("", description="Research methodology used")
+    sources_count: int = Field(0, description="Total number of sources consulted (computed)")
     report_date: str | None = Field(None, description="Report generation date")
-    confidence_level: str = Field(..., description="Overall confidence in findings: High, Medium, Low")
+    confidence_level: str = Field("Medium", description="Overall confidence in findings: High, Medium, Low")
+
+    @model_validator(mode="after")
+    def _count_sources(self) -> "DeepResearchReport":
+        """Derive ``sources_count`` from the sections instead of trusting the LLM.
+
+        Falls back to any value supplied on the model only when no section carries a
+        source, so a hand-built report with an explicit count is preserved.
+        """
+        counted = sum(len(section.sources) for section in self.research_sections)
+        self.sources_count = counted or self.sources_count
+        return self

--- a/tests/models/test_deep_research_report_resilience.py
+++ b/tests/models/test_deep_research_report_resilience.py
@@ -1,0 +1,100 @@
+"""The crew's output_pydantic contract must survive a small model's omissions.
+
+A production deep-research run (~9 minutes) failed at the final step with:
+
+    3 validation errors for DeepResearchReport
+    methodology      Field required
+    sources_count    Field required
+    confidence_level Field required
+
+The LLM had omitted three fields the model marked strictly required, and the task
+instructions themselves didn't list two of them as mandatory (and required a phantom
+`conclusions` field this model has never had). `sources_count` is worse: it's a
+computed integer no model should be asked to produce.
+
+These tests pin the resilient contract: the three fields default instead of hard-
+failing, and `sources_count` is derived from the sections, not trusted.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from epic_news.models.crews.deep_research_report import DeepResearchReport
+
+_SECTION = {
+    "section_title": "S1",
+    "content": "body",
+    "sources": [
+        {"title": "a", "url": "https://a", "source_type": "web", "summary": "s", "relevance_score": 8},
+        {"title": "b", "url": "https://b", "source_type": "web", "summary": "s", "relevance_score": 7},
+    ],
+}
+
+
+def _minimal(**overrides) -> dict:
+    base = {
+        "title": "T",
+        "topic": "Topic",
+        "executive_summary": "Summary",
+        "research_sections": [dict(_SECTION), {"section_title": "S2", "content": "b", "sources": []}],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_the_exact_production_omission_validates():
+    """methodology / sources_count / confidence_level all absent -> must not raise."""
+    report = DeepResearchReport.model_validate(_minimal())
+
+    assert report.methodology == ""
+    assert report.confidence_level == "Medium"
+
+
+def test_sources_count_is_computed_not_trusted():
+    """Counting is deterministic; the LLM's value is ignored when sections have sources."""
+    report = DeepResearchReport.model_validate(_minimal(sources_count=999))
+
+    assert report.sources_count == 2, "must reflect the 2 real sources, not the LLM's 999"
+
+
+def test_explicit_count_kept_when_no_section_carries_sources():
+    """A hand-built report with sourceless sections keeps its stated count."""
+    report = DeepResearchReport.model_validate(
+        _minimal(research_sections=[{"section_title": "S", "content": "c", "sources": []}], sources_count=15)
+    )
+
+    assert report.sources_count == 15
+
+
+def test_absent_count_defaults_to_zero():
+    report = DeepResearchReport.model_validate(
+        _minimal(research_sections=[{"section_title": "S", "content": "c", "sources": []}])
+    )
+
+    assert report.sources_count == 0
+
+
+def test_provided_values_are_respected():
+    report = DeepResearchReport.model_validate(_minimal(methodology="IMRaD", confidence_level="High"))
+
+    assert report.methodology == "IMRaD"
+    assert report.confidence_level == "High"
+
+
+def test_genuinely_required_fields_still_hard_fail():
+    """Resilience is scoped: the report is meaningless without a title/topic/summary."""
+    for missing in ("title", "topic", "executive_summary"):
+        payload = _minimal()
+        payload.pop(missing)
+        with pytest.raises(ValidationError):
+            DeepResearchReport.model_validate(payload)
+
+
+def test_phantom_fields_from_the_old_instructions_are_ignored():
+    """The old task example emitted conclusions/credibility_score/extraction_date."""
+    report = DeepResearchReport.model_validate(
+        _minimal(conclusions="general", research_sections=[{**_SECTION, "conclusions": "sec"}])
+    )
+
+    assert not hasattr(report, "conclusions")
+    assert report.sources_count == 2


### PR DESCRIPTION
## The bug

A ~9-minute deep-research run died at the very last step:

```
3 validation errors for DeepResearchReport
methodology       Field required
sources_count     Field required
confidence_level  Field required
```

`report.json` on disk from a *good* run contains all three — so this is intermittent, and it throws away the entire research run when it hits.

## Root cause

It's a contract mismatch, not a flaky model. The crew validates the LLM's one-shot JSON against `deep_research_report.py`'s `DeepResearchReport`, which marked those three fields **strictly required** (`...`). But:

- the task's own "champs obligatoires" list (`tasks.yaml`) omits `sources_count` and `confidence_level`, and requires a `conclusions` field this model has never had;
- the example JSON in the task describes the *other* class also named `DeepResearchReport` (the richer `models/crews/deep_research.py`, with `conclusions` / `credibility_score` / `extraction_date`).

The model was told one contract and validated against another. A run that followed the instructions literally lost everything. And `sources_count` is a *computed integer* — exactly the kind of deterministic value a model shouldn't be asked to produce (same lesson as the email fix).

## The fix

- `methodology` and `confidence_level` default instead of hard-failing; the renderer already reads both defensively (`.get()` + `if`). Same for `key_findings` / `research_sections` / section `sources` — same failure class.
- `sources_count` is **computed** from the sections via a `model_validator`, never trusted from the LLM. An explicit count is kept only when no section carries sources (hand-built reports).
- `report_writing_task`'s example + required-fields list rewritten to match this model exactly: no phantom `conclusions` / `credibility_score` / `extraction_date`, and an explicit "don't emit `sources_count`, it's computed."

Genuinely load-bearing fields (`title`, `topic`, `executive_summary`) stay required — resilience is scoped, not blanket.

## Verification

- Reproduced the exact production omission; it now validates with `sources_count` computed to the real value.
- Mutation-tested: restoring strict-required + trusting the LLM count fails 6 of 7 new tests.
- Full suite 684 passed, 5 skipped; ruff / mypy / yamllint clean.

## Note

Not a live end-to-end run — verified against the model contract and the reproduced payload. The next real deep-research run is the final confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KdBP4PYfXDbtCS1VjQcfSQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Deep research reports now handle incomplete generated data more reliably by applying sensible defaults.
  * Source counts are calculated automatically from the available research sections.
  * Report validation now enforces a clearer, stricter JSON structure and ignores unsupported fields.

* **Bug Fixes**
  * Reports remain valid when optional methodology, confidence, source counts, or source lists are omitted.
  * Required report details continue to be validated correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->