### PR TITLE
fix(crews): disable agent reasoning and remove flow memory

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,25 +1,28 @@
 
-
-# list of languages for which language servers are started; choose from:
-#   al                  angular             ansible             bash                clojure
-#   cpp                 cpp_ccls            crystal             csharp              csharp_omnisharp
-#   dart                elixir              elm                 erlang              fortran
-#   fsharp              go                  groovy              haskell             haxe
-#   hlsl                html                java                json                julia
-#   kotlin              lean4               lua                 luau                markdown
+# list of languages for which language servers are started (LSP backend only); choose from:
+#   ada                 al                  angular             ansible             bash
+#   bsl                 clojure             cpp                 cpp_ccls            crystal
+#   csharp              csharp_omnisharp    cue                 dart                elixir
+#   elm                 erlang              fortran             fsharp              gdscript
+#   go                  groovy              haskell             haxe                hlsl
+#   html                java                json                julia               kotlin
+#   latex               lean4               lua                 luau                markdown
 #   matlab              msl                 nix                 ocaml               pascal
-#   perl                php                 php_phpactor        powershell          python
-#   python_jedi         python_ty           r                   rego                ruby
-#   ruby_solargraph     rust                scala               scss                solidity
-#   swift               systemverilog       terraform           toml                typescript
-#   typescript_vts      vue                 yaml                zig
-#   (This list may be outdated. For the current list, see values of Language enum here:
-#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
-#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+#   perl                php                 php_phpactor        php_phpantom        powershell
+#   python              python_jedi         python_pyrefly      python_ty           r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   scss                solidity            svelte              swift               systemverilog
+#   terraform           toml                typescript          typescript_vts      vue
+#   yaml                zig
+#   (This list may be outdated; generated with scripts/print_language_list.py;
+#   For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py)
+# For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
 # Note:
 #   - For C, use cpp
 #   - For JavaScript, use typescript
 #   - For Angular projects, use angular (subsumes typescript+html; requires `npm install` in the project root)
+#   - For Svelte projects, use svelte (subsumes typescript/javascript for .svelte projects; requires npm)
 #   - For SCSS / Sass / plain CSS, use scss (some-sass-language-server handles all three)
 #   - For Free Pascal/Lazarus, use pascal
 # Special requirements:
@@ -56,7 +59,7 @@ excluded_tools: []
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
 initial_prompt: ""
-# the name by which the project can be referenced within Serena
+# the name by which the project can be referenced within Serena/when chatting with the LLM.
 project_name: "epic_news"
 
 # list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
@@ -119,8 +122,8 @@ ignored_memory_patterns: []
 
 # advanced configuration option allowing to configure language server-specific options.
 # Maps the language key to the options.
-# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
-# No documentation on options means no options are available.
+# The settings are considered only if the project is trusted (see global configuration to define trusted projects).
+# See https://oraios.github.io/serena/02-usage/050_configuration.html#language-server-specific-settings
 ls_specific_settings: {}
 
 # list of mode names to be activated additionally for this project, e.g. ["query-projects"]
@@ -128,13 +131,38 @@ ls_specific_settings: {}
 # See https://oraios.github.io/serena/02-usage/050_configuration.html#modes
 added_modes:
 
-# list of additional workspace folder paths for cross-package reference support (e.g. in monorepos).
+# list of additional workspace folder paths for cross-package reference support.
 # Paths can be absolute or relative to the project root.
 # Each folder is registered as an LSP workspace folder, enabling language servers to discover
-# symbols and references across package boundaries.
-# Currently supported for: TypeScript.
+# symbols and references across package boundaries, but these folders are not indexed by Serena,
+# i.e. the respective symbols will not be found using Serena's symbol search tools.
 # Example:
 #   additional_workspace_folders:
 #     - ../sibling-package
 #     - ../shared-lib
-additional_workspace_folders: []
+ls_additional_workspace_folders: []
+
+# list of workspace folder paths (LSP backend only).
+# These folders will be used to build up Serena's symbol index.
+# Paths must be within the project root and should thus be relative to the project root.
+# Furthermore, the paths should not be filtered by ignore settings.
+# Default setting: The entire project root folder (".") is considered.
+# In (large) monorepos, this can be used to index only subfolders of the project root, e.g.
+#   ls_workspace_folders:
+#     - "./subproject1"
+#     - "./subproject2"
+ls_workspace_folders:
+- .
+
+# optional shell command to run before the language backend (LSP or JetBrains) is initialised.
+# the command runs in the project root directory and is only executed if the project is trusted
+# (see trusted_project_path_patterns in the global configuration).
+# serena waits for the command to exit: a non-zero exit code is logged as an error but does not
+# abort activation. a per-project timeout (activation_command_timeout, default 180s) is the safety
+# backstop for non-terminating commands; on expiry the process is killed and activation continues.
+# example: activation_command: "npx nx run-many -t build"
+activation_command:
+
+# maximum time in seconds to wait for activation_command to complete before killing it (default 180s).
+# must be a positive number.
+activation_command_timeout: 180.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,8 @@ crewai flow kickoff    # or: make run-crew
 
 **NEVER** run crews directly via Python. The CrewAI Flow command is the only supported execution method.
 
+**Debugging kickoff failures**: `crewai flow kickoff` runs `uv run kickoff` in a subprocess and masks any crew crash behind a generic `Command '['uv', 'run', 'kickoff']' returned non-zero exit status 1`. The real traceback is printed by the subprocess *above* that line.
+
 ### Testing
 
 ```bash
@@ -183,6 +185,7 @@ Configuration in `src/epic_news/utils/logger.py`.
 7. **Using `os.makedirs()` in crews** → Use centralized `ensure_output_directories()`
 8. **Hardcoded LLM configuration** → Always use `LLMConfig.get_openrouter_llm()`, `LLMConfig.get_timeout()`, etc.
 9. **Hardcoded model names** → Use `MODEL` from `.env` via `LLMConfig`, never `llm="gpt-4o-mini"`
+10. **Enabling CrewAI `Memory`/RAG** → Project uses real-time retrieval, not memory; never pass `memory=Memory(...)` to a `Flow`/`Crew` (a LanceDB store with no embedder crashes kickoff)
 
 ## Python Version
 

--- a/docs/superpowers/plans/2026-07-11-prompt-enrichment.md
+++ b/docs/superpowers/plans/2026-07-11-prompt-enrichment.md
@@ -1,0 +1,398 @@
+# Prompt Enrichment Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a rephrase/enrich step to `InformationExtractionCrew` that rewrites the raw user request into a clean brief, so structured extraction fills reliably and downstream crews receive a rich `context`.
+
+**Architecture:** Extend the existing single-task `InformationExtractionCrew` into a two-task sequential crew: `enrich_request_task` (raw request → enriched brief) runs first, then the existing extraction task consumes it via `context=[...]`. `main.py::extract_info` captures the brief off `result.tasks_output[0].raw` into `state.enriched_brief`, and `ContentState.to_crew_inputs()` maps it to the `context` input every crew template can read.
+
+**Tech Stack:** CrewAI 1.15+ (`@CrewBase`, `@agent`, `@task`, `Process.sequential`), Pydantic v2, `LLMConfig` (OpenRouter), pytest, `uv`.
+
+## Global Constraints
+
+- Package manager is `uv` only — run tests with `uv run pytest` (never bare `pytest`, `pip`, or `poetry`).
+- Tools are assigned in Python `@agent` methods, never in YAML. The enrich agent has NO tools.
+- Use `LLMConfig.get_openrouter_llm()` and `LLMConfig.get_timeout(...)` — never hardcode model names or timeouts.
+- Pydantic fields use modern `X | None` syntax.
+- Faithfulness rule (copied from spec): the enrich agent must **reorganize and clarify only — never invent** facts (no fabricated budget, dates, traveler counts, or preferences).
+- Fallback rule: when the enrich output is empty/unusable, extraction and `state.enriched_brief` both fall back to the raw request — never worse than today.
+- Loguru for logging (`from loguru import logger`), not stdlib logging.
+- `ReceptionFlow(user_request=...)` stores the arg privately; `state.user_request` is only populated by `feed_user_request()`. In tests that call `extract_info()` directly, set `flow.state.user_request` explicitly.
+
+---
+
+### Task 1: `ContentState.enriched_brief` field + `context` injection
+
+**Files:**
+- Modify: `src/epic_news/models/content_state.py` (add field near `user_request`; add injection in `to_crew_inputs`)
+- Test: `tests/models/test_content_state_enriched_context.py`
+
+**Interfaces:**
+- Produces: `ContentState.enriched_brief: str | None` (default `None`); `to_crew_inputs()` returns a dict whose `"context"` equals `enriched_brief` when that field is truthy, otherwise the prior behaviour (extracted context or `""`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/models/test_content_state_enriched_context.py`:
+
+```python
+"""to_crew_inputs must surface the enriched brief as the downstream `context`."""
+
+from epic_news.models.content_state import ContentState
+
+
+def test_enriched_brief_becomes_context():
+    state = ContentState()
+    state.user_request = "raw messy request"
+    state.enriched_brief = "Clean family road-trip brief with all four cities"
+    inputs = state.to_crew_inputs()
+    assert inputs["context"] == "Clean family road-trip brief with all four cities"
+
+
+def test_no_enriched_brief_keeps_default_context():
+    state = ContentState()
+    state.user_request = "raw messy request"
+    inputs = state.to_crew_inputs()
+    # Unchanged behaviour: context stays the empty-string placeholder when nothing set it.
+    assert inputs.get("context", "") == ""
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/models/test_content_state_enriched_context.py -v`
+Expected: FAIL — `test_enriched_brief_becomes_context` raises `AttributeError: ... has no field "enriched_brief"` (Pydantic rejects the assignment).
+
+- [ ] **Step 3: Add the field**
+
+In `src/epic_news/models/content_state.py`, in the `REQUEST INFORMATION` block, immediately after the `extracted_info: ExtractedInfo | None = None` line, add:
+
+```python
+    enriched_brief: str | None = None
+```
+
+- [ ] **Step 4: Inject it as `context` in `to_crew_inputs`**
+
+In `src/epic_news/models/content_state.py`, in `to_crew_inputs`, locate the final return:
+
+```python
+        # Return clean dictionary, removing None values but keeping required placeholders
+        return {k: v for k, v in inputs.items() if v is not None}
+```
+
+Immediately **before** that return, add:
+
+```python
+        # The enriched brief is a clean, complete rewrite of the whole request, so it is
+        # the best working context for any downstream crew. Prefer it; fall back to
+        # whatever context extraction produced (or the placeholder) when absent.
+        if self.enriched_brief:
+            inputs["context"] = self.enriched_brief
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/models/test_content_state_enriched_context.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/epic_news/models/content_state.py tests/models/test_content_state_enriched_context.py
+git commit -m "feat(state): add enriched_brief and surface it as downstream context"
+```
+
+---
+
+### Task 2: Add enrich agent + task to `InformationExtractionCrew`
+
+**Files:**
+- Modify: `src/epic_news/crews/information_extraction/config/agents.yaml` (add `prompt_enricher_agent`)
+- Modify: `src/epic_news/crews/information_extraction/config/tasks.yaml` (add `enrich_request_task`)
+- Modify: `src/epic_news/crews/information_extraction/information_extraction_crew.py` (add agent method + task method defined BEFORE the extraction task; wire `context`)
+- Test: `tests/crews/test_information_extraction_enrich.py`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: a 2-agent / 2-task crew. `crew.tasks[0]` is the enrich task (plain text output, no `output_pydantic`); `crew.tasks[1]` is the extraction task with `output_pydantic is ExtractedInfo` and a non-empty `context` list containing the enrich task. Task execution/definition order is enrich-first.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/crews/test_information_extraction_enrich.py`:
+
+```python
+"""InformationExtractionCrew runs an enrich task before extraction, and the
+extraction task consumes the enriched brief as context."""
+
+from epic_news.crews.information_extraction.information_extraction_crew import (
+    InformationExtractionCrew,
+)
+from epic_news.models.extracted_info import ExtractedInfo
+
+
+def test_crew_has_two_agents_and_two_tasks():
+    crew = InformationExtractionCrew().crew()
+    assert len(crew.agents) == 2
+    assert len(crew.tasks) == 2
+
+
+def test_enrich_runs_first_and_extraction_consumes_it():
+    crew = InformationExtractionCrew().crew()
+    enrich_task, extract_task = crew.tasks[0], crew.tasks[1]
+
+    # Enrich task emits plain text (the brief), not the structured model.
+    assert enrich_task.output_pydantic is None
+    # Extraction task still produces ExtractedInfo, and now reads the enrich task.
+    assert extract_task.output_pydantic is ExtractedInfo
+    assert extract_task.context, "extraction task must consume the enrich task as context"
+    assert enrich_task in extract_task.context
+
+
+def test_faithfulness_guard_is_present_in_config():
+    """The 'never invent' constraint is the core safety property — lock it in so a
+    future edit can't quietly drop it. Real LLM faithfulness is checked manually
+    (see the plan's end-to-end verification), not in CI."""
+    ie = InformationExtractionCrew()
+    agent_backstory = ie.prompt_enricher_agent().backstory.lower()
+    task_desc = ie.enrich_request_task().description.lower()
+    assert "never invent" in agent_backstory
+    assert "do not" in task_desc and "invent" in task_desc
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/crews/test_information_extraction_enrich.py -v`
+Expected: FAIL — `test_crew_has_two_agents_and_two_tasks` asserts 2 but the crew currently has 1 agent / 1 task.
+
+- [ ] **Step 3: Add the enrich agent to `agents.yaml`**
+
+Append to `src/epic_news/crews/information_extraction/config/agents.yaml`:
+
+```yaml
+prompt_enricher_agent:
+  role: >
+    Request Clarity Editor
+  goal: >
+    Rewrite a user's raw request into a single clear, well-structured brief that a
+    downstream specialist can act on without re-reading the original. Preserve every
+    fact; add nothing.
+  backstory: >-
+    You are a precise editor. You take rambling, multi-part, or multilingual requests
+    and reorganise them into one coherent brief: who, what, where, when, and any stated
+    preferences or constraints. You NEVER invent details — no budgets, dates, traveler
+    counts, or preferences the user did not state. If a detail is missing, you leave it
+    out rather than guessing. You keep the user's original language.
+```
+
+- [ ] **Step 4: Add the enrich task to `tasks.yaml`**
+
+Add to `src/epic_news/crews/information_extraction/config/tasks.yaml` (place it **above** `comprehensive_information_extraction_task` for readability; task order is controlled in Python, not YAML):
+
+```yaml
+enrich_request_task:
+  description: >
+    Rewrite the following user request into ONE clear, well-organised brief that a
+    downstream specialist can act on directly. Reorganise and clarify only — do NOT
+    add, infer, or invent any facts that are not present in the original (no budgets,
+    dates, traveler counts, destinations, or preferences the user did not state). If a
+    detail is absent, leave it out. Preserve the user's original language. When the
+    request lists several places, stages, or steps, keep them all, in order.
+    Negative example: if the user says "a week in Anglet with my family", do NOT write
+    "a week in Anglet with my family of four on a mid-range budget" — the family size and
+    budget were never stated. Write only what was given.
+    User request: "{user_request}"
+  expected_output: >
+    A single concise brief in plain prose (no JSON, no bullet headers required),
+    written in the same language as the request, containing every concrete detail the
+    user gave and nothing they did not.
+  agent: prompt_enricher_agent
+```
+
+- [ ] **Step 5: Wire the crew — add the agent + task methods, extraction consumes enrich**
+
+Edit `src/epic_news/crews/information_extraction/information_extraction_crew.py`. Add the enrich agent method and the enrich task method **before** `comprehensive_information_extraction_task`, and add `context=` to the extraction task. Replace the body between the class docstring/config lines and the `@crew` method with:
+
+```python
+    @agent
+    def prompt_enricher_agent(self) -> Agent:
+        """Agent that rewrites the raw request into a clean, faithful brief."""
+        return Agent(
+            config=cast(dict[str, Any], self.agents_config)["prompt_enricher_agent"],
+            llm=LLMConfig.get_openrouter_llm(),
+            llm_timeout=LLMConfig.get_timeout("quick"),
+            verbose=True,
+        )
+
+    @agent
+    def detailed_request_analyzer_agent(self) -> Agent:
+        """Agent that analyzes the user request in detail."""
+        return Agent(
+            config=cast(dict[str, Any], self.agents_config)["detailed_request_analyzer_agent"],
+            llm=LLMConfig.get_openrouter_llm(),
+            llm_timeout=LLMConfig.get_timeout("default"),
+            verbose=True,
+        )
+
+    @task
+    def enrich_request_task(self) -> Task:
+        """Task that produces the enriched brief (runs first)."""
+        return Task(  # type: ignore[call-arg]
+            config=cast(dict[str, Any], self.tasks_config)["enrich_request_task"],
+            agent=self.prompt_enricher_agent(),  # type: ignore[call-arg]
+        )
+
+    @task
+    def comprehensive_information_extraction_task(self) -> Task:
+        """Task to extract information into a Pydantic model from the enriched brief."""
+        return Task(  # type: ignore[call-arg]
+            config=cast(dict[str, Any], self.tasks_config)["comprehensive_information_extraction_task"],
+            agent=self.detailed_request_analyzer_agent(),  # type: ignore[call-arg]
+            context=[self.enrich_request_task()],  # type: ignore[call-arg]
+            output_pydantic=ExtractedInfo,
+        )
+```
+
+Leave the `@crew` method unchanged (it already builds from `self.agents` / `self.tasks`).
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `uv run pytest tests/crews/test_information_extraction_enrich.py -v`
+Expected: PASS (3 passed).
+
+- [ ] **Step 7: Guard against async-agent regression (existing suite)**
+
+Run: `uv run pytest tests/crews/ -q`
+Expected: PASS — the crew still builds; no shared-agent/async violations.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/epic_news/crews/information_extraction/ tests/crews/test_information_extraction_enrich.py
+git commit -m "feat(extraction): enrich the request before extracting structured fields"
+```
+
+---
+
+### Task 3: Capture the enriched brief in `main.py::extract_info`
+
+**Files:**
+- Modify: `src/epic_news/main.py` (the `extract_info` method)
+- Test: `tests/flows/test_extract_info_enriched_brief.py`
+
+**Interfaces:**
+- Consumes: `kickoff_flow(...)` returns a CrewOutput-like object with `.pydantic` (the `ExtractedInfo`) and `.tasks_output` (a list whose `[0].raw` is the enriched brief). It also stores `state.user_request` (set upstream by `feed_user_request`).
+- Produces: after `extract_info()`, `state.enriched_brief` is the brief text, or `state.user_request` when no usable brief is present.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/flows/test_extract_info_enriched_brief.py`:
+
+```python
+"""extract_info stores the enriched brief on state, falling back to the raw request."""
+
+import epic_news.main as main_mod
+from epic_news.main import ReceptionFlow
+
+
+class _TaskOutput:
+    def __init__(self, raw):
+        self.raw = raw
+
+
+class _Result:
+    def __init__(self, tasks_output, pydantic=None):
+        self.tasks_output = tasks_output
+        self.pydantic = pydantic
+
+
+def _flow(monkeypatch, result):
+    flow = ReceptionFlow(user_request="raw messy request")
+    flow.state.user_request = "raw messy request"
+    monkeypatch.setattr(main_mod, "kickoff_flow", lambda *a, **k: result)
+    monkeypatch.setattr(main_mod, "dump_crewai_state", lambda *a, **k: None)
+    return flow
+
+
+def test_captures_enriched_brief(monkeypatch):
+    result = _Result([_TaskOutput("Clean brief"), _TaskOutput("{}")], pydantic=None)
+    flow = _flow(monkeypatch, result)
+
+    flow.extract_info()
+
+    assert flow.state.enriched_brief == "Clean brief"
+
+
+def test_falls_back_to_raw_request_when_no_brief(monkeypatch):
+    result = _Result([], pydantic=None)  # crew produced no task outputs
+    flow = _flow(monkeypatch, result)
+
+    flow.extract_info()
+
+    assert flow.state.enriched_brief == "raw messy request"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/flows/test_extract_info_enriched_brief.py -v`
+Expected: FAIL — `state.enriched_brief` is `None` (extract_info does not set it yet), so both asserts fail.
+
+- [ ] **Step 3: Implement brief capture in `extract_info`**
+
+In `src/epic_news/main.py`, find the `extract_info` body:
+
+```python
+        extraction_crew = InformationExtractionCrew()
+        extracted_data = kickoff_flow(extraction_crew, {"user_request": self.state.user_request})
+
+        dump_crewai_state(extracted_data, "EXTRACTED_INFO")
+        # Update the state with the extracted information
+        if extracted_data:
+            # Assuming extracted_data has a .pydantic attribute for the model instance
+            self.state.extracted_info = extracted_data.pydantic
+            self.logger.info("✅ Information extraction complete.")
+        else:
+            self.logger.warning("⚠️ Information extraction failed or returned no data.")
+```
+
+Insert brief capture immediately after the `dump_crewai_state(...)` line (before `if extracted_data:`):
+
+```python
+        # The enrich task runs first, so its brief is the first task output. Store it as
+        # the working context for downstream crews; fall back to the raw request when the
+        # crew produced no usable brief (never worse than mailing the raw request).
+        tasks_output = getattr(extracted_data, "tasks_output", None) or []
+        brief = tasks_output[0].raw.strip() if tasks_output and tasks_output[0].raw else ""
+        self.state.enriched_brief = brief or self.state.user_request
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/flows/test_extract_info_enriched_brief.py -v`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Run the broader flow + model suites for regressions**
+
+Run: `uv run pytest tests/flows/ tests/models/ tests/crews/ -q`
+Expected: PASS (includes the shipped `test_holiday_no_destination.py` and Tasks 1–2 tests).
+
+- [ ] **Step 6: Lint & format the changed files**
+
+Run: `uv run ruff check --fix src/epic_news/main.py src/epic_news/models/content_state.py src/epic_news/crews/information_extraction/information_extraction_crew.py && uv run ruff format .`
+Expected: no remaining errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/epic_news/main.py tests/flows/test_extract_info_enriched_brief.py
+git commit -m "feat(flow): capture the enriched brief into state during extraction"
+```
+
+---
+
+## Manual end-to-end verification (after Task 3)
+
+The automated tests stub the LLM. To confirm the real pipeline, run the original failing request through the flow with email disabled and inspect the extracted fields + brief:
+
+- Set `EPIC_ENABLE_EMAIL=false`.
+- Kick off with the Montreux→Montpellier→Anglet→Poitiers→Bourges request (the default in `main.py::kickoff`).
+- Confirm in `./debug/crewai_state_extracted_info_*.json` that `destination_location` (and ideally `origin_location`/`event_or_trip_duration`) are now populated, and that `output/holiday/itinerary.html` is written (crew ran).
+
+This is a human check, not a CI test (it makes live LLM calls).

--- a/docs/superpowers/specs/2026-07-11-prompt-enrichment-design.md
+++ b/docs/superpowers/specs/2026-07-11-prompt-enrichment-design.md
@@ -1,0 +1,125 @@
+# Prompt Enrichment in InformationExtractionCrew
+
+**Date:** 2026-07-11
+**Status:** Approved (design), pending implementation plan
+
+## Problem
+
+A real HOLIDAY_PLANNER run for a multi-stop road-trip request
+(Montreux→Montpellier→Anglet→Poitiers→Bourges, French) produced no itinerary and
+emailed the classifier's `decision.md` instead. Root cause: the request describes a
+*route*, not a single destination, so `InformationExtractionCrew` dumped everything
+into the free-text blob and left every structured travel field (`destination_location`,
+`origin_location`, `event_or_trip_duration`, `traveler_details`) `None`.
+
+A guard + fallback for that specific failure already shipped (see
+`tests/flows/test_holiday_no_destination.py`). This spec addresses the upstream quality
+lever: **messy, underspecified requests degrade extraction and, downstream, answer
+quality across all crews.**
+
+## Goal
+
+Add a rephrase/enrich step that rewrites the raw user request into a clean, structured
+brief. Downstream benefits are twofold:
+
+1. Extraction runs on the clean brief, so structured fields fill reliably (a side
+   effect that would have prevented the road-trip failure).
+2. The enriched brief is passed to the downstream crew as `context`, giving it a
+   rich, well-organized narrative to work from.
+
+Non-goals: interactive user clarification loops; changing the `ExtractedInfo` schema;
+altering classification or routing.
+
+## Architecture
+
+A new enrich task runs **first**, feeding a cleaned brief into the existing extraction
+task. One crew, one kickoff, one flow step — `main.py::extract_info` keeps its shape.
+
+```
+feed_user_request
+   ▼
+extract_info  (single kickoff of the extended crew)
+   ├─ enrich_request_task                  : raw request → enriched_brief (plain text)
+   └─ comprehensive_information_extraction_task
+        : ExtractedInfo, context=[enrich_request_task]   ← extracts from the clean brief
+   ▼
+classify → route → generate_<crew>
+```
+
+## Components
+
+1. **New agent** `prompt_enricher_agent` (`config/agents.yaml`) — "Request Clarity
+   Editor". No tools. Uses `LLMConfig.get_openrouter_llm()` and
+   `LLMConfig.get_timeout("quick")`.
+2. **New task** `enrich_request_task` (`config/tasks.yaml`) — outputs the enriched
+   brief as plain text. Runs first (sequential process, listed before the extraction
+   task).
+3. **Existing task** `comprehensive_information_extraction_task` — gains
+   `context=[self.enrich_request_task()]` so it extracts from the clean brief instead
+   of the raw request.
+4. **`ExtractedInfo`** (`src/epic_news/models/extracted_info.py`) — unchanged.
+5. **`main.py::extract_info`** — after kickoff, read the enriched brief from
+   `result.tasks_output[0].raw` and store `self.state.enriched_brief`. Falls back to
+   the raw request when that output is empty/unusable.
+6. **`ContentState`** (`src/epic_news/models/content_state.py`) — new field
+   `enriched_brief: str | None = None`; `to_crew_inputs()` sets
+   `context = enriched_brief or user_request` so downstream task templates that already
+   reference `{context}` receive the rich narrative.
+
+## Data Flow
+
+```
+raw user_request
+   │
+   ▼  enrich_request_task (LLM: reorganize + clarify, never invent)
+enriched_brief ──────────────┬──────────────────────────────┐
+   │                         │                               │
+   ▼ context=[enrich]        ▼ state.enriched_brief          │
+extract_task            (stored on ContentState)             │
+   │                         │                               │
+   ▼                         ▼ to_crew_inputs()              │
+ExtractedInfo           context = enriched_brief ────────────┘
+   │                         │
+   ▼ field mapping           ▼
+destination/duration/... + context  →  downstream crew inputs
+```
+
+## Error Handling
+
+- **Faithfulness gate (critical):** the enrich agent is constrained to *reorganize and
+  clarify only — never invent* facts. It must not fabricate budget, dates, traveler
+  counts, or preferences the user did not state. The task prompt states this explicitly
+  with a negative example. This is the primary risk of a "improve the prompt" step and
+  the main thing tests must defend.
+- **Fallback:** if `enrich_request_task` output is empty or unusable, extraction and
+  `state.enriched_brief` both fall back to the raw request — behavior is never worse
+  than today.
+- **Backstop:** the already-shipped road-trip fallback in `generate_holiday_plan`
+  remains, so even a degraded enrich/extract cannot reintroduce the empty-destination
+  failure.
+
+## Testing
+
+1. **Enrich quality:** the multi-city French request yields a brief containing all four
+   cities and the dates. Uses a canned/stubbed LLM output for determinism (no live LLM
+   in CI).
+2. **Wiring:** `extract_info` populates `state.enriched_brief`; `to_crew_inputs()` maps
+   it to `context`.
+3. **Faithfulness regression:** faithfulness is enforced at the prompt level ("clarify,
+   never invent"). The test uses a canned enrich output for a minimal request ("write a
+   poem about Rome") and asserts the resulting `ExtractedInfo` and `context` introduce
+   no travel/budget/traveler fields that were absent from the source — i.e. enrichment
+   did not fabricate structure.
+4. **Fallback:** empty enrich output → extraction still runs on the raw request and
+   `state.enriched_brief` equals the raw request.
+
+## Cost
+
+Adds **one LLM call per request** (all requests, not just travel), sized to the "quick"
+timeout. Accepted for the across-the-board quality lift.
+
+## Related
+
+- Shipped guard/fallback: `tests/flows/test_holiday_no_destination.py`,
+  `src/epic_news/main.py` (`CLASSIFY_DECISION_FILE`, holiday fallback).
+- Extraction crew: `src/epic_news/crews/information_extraction/`.

--- a/src/epic_news/crews/company_news/company_news_crew.py
+++ b/src/epic_news/crews/company_news/company_news_crew.py
@@ -75,7 +75,7 @@ class CompanyNewsCrew:
             verbose=True,
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("default"),
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
             respect_context_window=True,
         )
@@ -93,7 +93,7 @@ class CompanyNewsCrew:
             verbose=True,
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("default"),
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
             respect_context_window=True,
         )
@@ -111,7 +111,7 @@ class CompanyNewsCrew:
             verbose=True,
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("default"),
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
             respect_context_window=True,
         )

--- a/src/epic_news/crews/company_profiler/company_profiler_crew.py
+++ b/src/epic_news/crews/company_profiler/company_profiler_crew.py
@@ -37,7 +37,7 @@ class CompanyProfilerCrew:
             verbose=True,
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 
@@ -52,7 +52,7 @@ class CompanyProfilerCrew:
             verbose=True,
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 

--- a/src/epic_news/crews/cross_reference_report_crew/cross_reference_report_crew.py
+++ b/src/epic_news/crews/cross_reference_report_crew/cross_reference_report_crew.py
@@ -42,7 +42,7 @@ class CrossReferenceReportCrew:
             llm_timeout=LLMConfig.get_timeout("default"),
             allow_delegation=True,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=5,
         )
 
@@ -57,7 +57,7 @@ class CrossReferenceReportCrew:
             verbose=True,
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 

--- a/src/epic_news/crews/deep_research/deep_research.py
+++ b/src/epic_news/crews/deep_research/deep_research.py
@@ -66,7 +66,7 @@ class DeepResearchCrew:
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("long"),
             verbose=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 

--- a/src/epic_news/crews/geospatial_analysis/geospatial_analysis_crew.py
+++ b/src/epic_news/crews/geospatial_analysis/geospatial_analysis_crew.py
@@ -39,7 +39,7 @@ class GeospatialAnalysisCrew:
             llm_timeout=LLMConfig.get_timeout("default"),
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=5,
             max_retry_limit=3,
         )
@@ -55,7 +55,7 @@ class GeospatialAnalysisCrew:
             llm_timeout=LLMConfig.get_timeout("default"),
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 

--- a/src/epic_news/crews/holiday_planner/holiday_planner_crew.py
+++ b/src/epic_news/crews/holiday_planner/holiday_planner_crew.py
@@ -25,7 +25,7 @@ class HolidayPlannerCrew:
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("default"),
             verbose=False,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
             allow_delegation=True,
         )
@@ -38,7 +38,7 @@ class HolidayPlannerCrew:
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("default"),
             verbose=False,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
             allow_delegation=True,
         )
@@ -51,7 +51,7 @@ class HolidayPlannerCrew:
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("default"),
             verbose=False,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
             allow_delegation=True,
         )

--- a/src/epic_news/crews/holiday_planner/holiday_planner_crew.py
+++ b/src/epic_news/crews/holiday_planner/holiday_planner_crew.py
@@ -69,9 +69,14 @@ class HolidayPlannerCrew:
 
     @agent
     def content_formatter(self) -> Agent:
+        # No tools: this agent runs the final format_and_translate_guide task, which
+        # carries output_pydantic=HolidayPlannerReport. With tools, CrewAI 1.15 can leak
+        # a tool-call result (e.g. ExchangeRateTool's {base_currency, target_currencies})
+        # into TaskOutput.raw, which then fails HolidayPlannerReport validation. The
+        # reporter synthesizes solely from the prior tasks' context (crews/CLAUDE.md
+        # two-agent pattern: reporter has no tools = clean structured output).
         return Agent(
             config=self.agents_config["content_formatter"],  # type: ignore[index]
-            tools=get_search_tools() + get_scrape_tools() + [ExchangeRateTool()],
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("default"),
             verbose=False,

--- a/src/epic_news/crews/hr_intelligence/hr_intelligence_crew.py
+++ b/src/epic_news/crews/hr_intelligence/hr_intelligence_crew.py
@@ -37,7 +37,7 @@ class HRIntelligenceCrew:
             llm_timeout=LLMConfig.get_timeout("default"),
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 
@@ -52,7 +52,7 @@ class HRIntelligenceCrew:
             llm_timeout=LLMConfig.get_timeout("default"),
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
         )
 
     @task

--- a/src/epic_news/crews/information_extraction/config/agents.yaml
+++ b/src/epic_news/crews/information_extraction/config/agents.yaml
@@ -12,3 +12,17 @@ detailed_request_analyzer_agent:
     understanding nuanced human language and converting it into precise,  structured
     data. Your sole purpose is to populate a Pydantic model with  information found
     in the user's text. You are methodical, accurate, and  leave no detail overlooked.
+
+prompt_enricher_agent:
+  role: >
+    Request Clarity Editor
+  goal: >
+    Rewrite a user's raw request into a single clear, well-structured brief that a
+    downstream specialist can act on without re-reading the original. Preserve every
+    fact; add nothing.
+  backstory: >-
+    You are a precise editor. You take rambling, multi-part, or multilingual requests
+    and reorganise them into one coherent brief: who, what, where, when, and any stated
+    preferences or constraints. You NEVER invent details — no budgets, dates, traveler
+    counts, or preferences the user did not state. If a detail is missing, you leave it
+    out rather than guessing. You keep the user's original language.

--- a/src/epic_news/crews/information_extraction/config/tasks.yaml
+++ b/src/epic_news/crews/information_extraction/config/tasks.yaml
@@ -35,7 +35,14 @@ comprehensive_information_extraction_task:
     extract any relevant information from the user's request and populate the
     corresponding fields. The 'main_subject_or_activity' is the most critical
     field. It is perfectly acceptable for most fields to be null if the
-    information is not present.-
+    information is not present.
+    'user_preferences_and_constraints' MUST be a SINGLE concise paragraph
+    (roughly 400 characters or less). State each preference or constraint
+    exactly once — never repeat phrases, lists, or the itinerary. Repetition
+    is a defect.
+    For a multi-stop trip (a road trip visiting several places), put the whole
+    route in 'destination_location' as an ordered list of the stops — do NOT
+    leave it null just because there is more than one place.-
     Here are some examples to guide you:
     Example 1: - Request: "I want to plan a 2-week holiday to Greece for 2
     adults. We are looking for something relaxing and on a budget." - Correct
@@ -89,5 +96,20 @@ comprehensive_information_extraction_task:
       - company: "Reyl"
       - destination_location: "Switzerland"
       - main_subject_or_activity: "PESTEL analysis of Reyl bank in Switzerland"
+      - output_language: "French"
+    Example 8 (multi-stop road trip): - Request: "En famille à 3 nous partons 2
+    semaines en voiture du 16 au 31 juillet. De Montreux à Montpellier, puis
+    Anglet, puis Poitiers, puis Bourges. Les hôtels sont déjà réservés. Donne-moi
+    un itinéraire avec restaurants et activités pour un enfant de 11 ans."
+    - Correct Output Fields:
+      - origin_location: "Montreux"
+      - destination_location: "Montpellier, Anglet, Poitiers, Bourges"
+      - traveler_details: "Family of 3 including an 11-year-old child"
+      - participants:
+        - "Family of 3 including an 11-year-old child"
+      - event_or_trip_duration: "2 weeks (16-31 July)"
+      - main_subject_or_activity: "family road-trip itinerary planning"
+      - user_preferences_and_constraints: "Traveling by car; hotels already booked;
+    wants restaurants, activities and cultural visits suitable for an 11-year-old."
       - output_language: "French"
   agent: detailed_request_analyzer_agent

--- a/src/epic_news/crews/information_extraction/config/tasks.yaml
+++ b/src/epic_news/crews/information_extraction/config/tasks.yaml
@@ -1,4 +1,22 @@
 ---
+enrich_request_task:
+  description: >
+    Rewrite the following user request into ONE clear, well-organised brief that a
+    downstream specialist can act on directly. Reorganise and clarify only — do NOT
+    add, infer, or invent any facts that are not present in the original (no budgets,
+    dates, traveler counts, destinations, or preferences the user did not state). If a
+    detail is absent, leave it out. Preserve the user's original language. When the
+    request lists several places, stages, or steps, keep them all, in order.
+    Negative example: if the user says "a week in Anglet with my family", do NOT write
+    "a week in Anglet with my family of four on a mid-range budget" — the family size and
+    budget were never stated. Write only what was given.
+    User request: "{user_request}"
+  expected_output: >
+    A single concise brief in plain prose (no JSON, no bullet headers required),
+    written in the same language as the request, containing every concrete detail the
+    user gave and nothing they did not.
+  agent: prompt_enricher_agent
+
 comprehensive_information_extraction_task:
   description: >
     Analyze the user's request to identify key pieces of information. Your

--- a/src/epic_news/crews/information_extraction/information_extraction_crew.py
+++ b/src/epic_news/crews/information_extraction/information_extraction_crew.py
@@ -15,6 +15,16 @@ class InformationExtractionCrew:
     tasks_config = "config/tasks.yaml"
 
     @agent
+    def prompt_enricher_agent(self) -> Agent:
+        """Agent that rewrites the raw request into a clean, faithful brief."""
+        return Agent(
+            config=cast(dict[str, Any], self.agents_config)["prompt_enricher_agent"],
+            llm=LLMConfig.get_openrouter_llm(),
+            llm_timeout=LLMConfig.get_timeout("quick"),
+            verbose=True,
+        )
+
+    @agent
     def detailed_request_analyzer_agent(self) -> Agent:
         """Agent that analyzes the user request in detail."""
         return Agent(
@@ -25,11 +35,20 @@ class InformationExtractionCrew:
         )
 
     @task
+    def enrich_request_task(self) -> Task:
+        """Task that produces the enriched brief (runs first)."""
+        return Task(  # type: ignore[call-arg]
+            config=cast(dict[str, Any], self.tasks_config)["enrich_request_task"],
+            agent=self.prompt_enricher_agent(),  # type: ignore[call-arg]
+        )
+
+    @task
     def comprehensive_information_extraction_task(self) -> Task:
-        """Task to extract information into a Pydantic model."""
+        """Task to extract information into a Pydantic model from the enriched brief."""
         return Task(  # type: ignore[call-arg]
             config=cast(dict[str, Any], self.tasks_config)["comprehensive_information_extraction_task"],
             agent=self.detailed_request_analyzer_agent(),  # type: ignore[call-arg]
+            context=[self.enrich_request_task()],  # type: ignore[call-arg]
             output_pydantic=ExtractedInfo,
         )
 

--- a/src/epic_news/crews/legal_analysis/legal_analysis_crew.py
+++ b/src/epic_news/crews/legal_analysis/legal_analysis_crew.py
@@ -37,7 +37,7 @@ class LegalAnalysisCrew:
             llm_timeout=LLMConfig.get_timeout("default"),
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=5,
         )
 
@@ -52,7 +52,7 @@ class LegalAnalysisCrew:
             verbose=True,
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 

--- a/src/epic_news/crews/meeting_prep/meeting_prep_crew.py
+++ b/src/epic_news/crews/meeting_prep/meeting_prep_crew.py
@@ -28,7 +28,7 @@ class MeetingPrepCrew:
             config=self.agents_config["lead_researcher_agent"],  # type: ignore[index]
             tools=get_search_tools() + get_scrape_tools() + get_yahoo_finance_tools(),
             allow_delegation=False,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
             verbose=True,
             respect_context_window=True,
@@ -59,7 +59,7 @@ class MeetingPrepCrew:
         return Agent(
             config=self.agents_config["sales_strategist_agent"],  # type: ignore[index]
             tools=get_search_tools() + get_scrape_tools() + get_yahoo_finance_tools(),
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
             verbose=True,
             respect_context_window=True,

--- a/src/epic_news/crews/menu_designer/menu_designer.py
+++ b/src/epic_news/crews/menu_designer/menu_designer.py
@@ -32,7 +32,7 @@ class MenuDesignerCrew:
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("default"),
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
             verbose=True,
         )
@@ -46,7 +46,7 @@ class MenuDesignerCrew:
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("default"),
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
             verbose=True,
         )

--- a/src/epic_news/crews/news_daily/news_daily.py
+++ b/src/epic_news/crews/news_daily/news_daily.py
@@ -33,7 +33,7 @@ class NewsDailyCrew:
             config=self.agents_config["content_curator"],
             tools=[],
             verbose=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("default"),

--- a/src/epic_news/crews/pestel/pestel_crew.py
+++ b/src/epic_news/crews/pestel/pestel_crew.py
@@ -63,7 +63,7 @@ class PestelCrew:
             verbose=True,
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 
@@ -101,7 +101,7 @@ class PestelCrew:
             verbose=True,
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 

--- a/src/epic_news/crews/sales_prospecting/sales_prospecting_crew.py
+++ b/src/epic_news/crews/sales_prospecting/sales_prospecting_crew.py
@@ -84,7 +84,7 @@ class SalesProspectingCrew:
             llm=LLMConfig.get_openrouter_llm(),
             llm_timeout=LLMConfig.get_timeout("default"),
             verbose=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=5,
             respect_context_window=True,
         )

--- a/src/epic_news/crews/tech_stack/tech_stack_crew.py
+++ b/src/epic_news/crews/tech_stack/tech_stack_crew.py
@@ -36,7 +36,7 @@ class TechStackCrew:
             verbose=True,
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 
@@ -51,7 +51,7 @@ class TechStackCrew:
             verbose=True,
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 

--- a/src/epic_news/crews/web_presence/web_presence_crew.py
+++ b/src/epic_news/crews/web_presence/web_presence_crew.py
@@ -33,7 +33,7 @@ class WebPresenceCrew:
             verbose=True,
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=5,
             max_retry_limit=3,
         )
@@ -49,7 +49,7 @@ class WebPresenceCrew:
             verbose=True,
             allow_delegation=False,
             respect_context_window=True,
-            reasoning=True,
+            reasoning=False,
             max_reasoning_attempts=3,
         )
 

--- a/src/epic_news/main.py
+++ b/src/epic_news/main.py
@@ -130,6 +130,11 @@ tracer = observability_tools["tracer"]
 dashboard = observability_tools["dashboard"]
 hallucination_guard = observability_tools["hallucination_guard"]
 
+# Where the classifier writes its routing decision. It is NOT a rendered report: if
+# state.output_file still points here at email time, no crew produced a report and the
+# email step must refuse to deliver this JSON as if it were one.
+CLASSIFY_DECISION_FILE = "output/classify/decision.md"
+
 """                                                                                      """
 """                     All the magic is here                                            """
 """                                                                                      """
@@ -253,7 +258,7 @@ class ReceptionFlow(Flow[ContentState]):
         )
         self.logger.info(f"Routing request: '{self.state.user_request}' with topic: '{topic}'")
         # Define the output file path for the classification decision.
-        self.state.output_file = "output/classify/decision.md"
+        self.state.output_file = CLASSIFY_DECISION_FILE
 
         # Prepare input data for classification using the centralized method from ContentState.
         inputs = self.state.to_crew_inputs()
@@ -1326,16 +1331,24 @@ class ReceptionFlow(Flow[ContentState]):
         Handles requests classified for the 'HolidayPlannerCrew'.
 
         Invokes the `HolidayPlannerCrew` to generate a holiday itinerary.
-        Requires a 'destination' in the inputs. Sets `output_file` to
-        `output/travel_guides/itinerary.html` and stores the plan in
-        `self.state.holiday_plan`. Returns 'error' if no destination is found.
+        When extraction yields no single 'destination' (e.g. a multi-stop road
+        trip), falls back to the raw user request so the crew still runs. Sets
+        `output_file` to `output/holiday/itinerary.html` and stores the plan in
+        `self.state.holiday_plan`.
         """
         current_inputs = self.state.to_crew_inputs()
         current_inputs["output_file"] = "output/holiday/itinerary.json"
 
         if not current_inputs.get("destination"):
-            self.logger.warning("⚠️ No destination found for holiday plan; skipping crew execution.")
-            return None
+            # A multi-stop road trip (Montreux→Montpellier→Anglet→…) has no single
+            # "destination", so extraction routinely leaves destination_location empty
+            # even when the request is full of places. Skipping here silently left
+            # output_file at the classifier's decision.md and emailed that instead of an
+            # itinerary. Fall back to the raw request, which carries the full route.
+            self.logger.warning(
+                "⚠️ No structured destination extracted; falling back to the raw user request."
+            )
+            current_inputs["destination"] = self.state.user_request
 
         # Ensure all required template variables are provided with defaults
         required_vars = {
@@ -1409,6 +1422,19 @@ class ReceptionFlow(Flow[ContentState]):
                     flag,
                 )
                 self.state.email_sent = True
+                return "send_email"
+
+            # No report was generated: output_file still points at the classifier's
+            # decision file. Mailing it would deliver the routing JSON as if it were the
+            # user's report (a real HOLIDAY_PLANNER run did exactly this). Refuse, and
+            # leave email_sent False so the failure is visible rather than papered over.
+            if self.state.output_file == CLASSIFY_DECISION_FILE:
+                self.logger.error(
+                    "🚫 No report was generated (output_file still {}); refusing to email "
+                    "the classification decision as a report.",
+                    self.state.output_file,
+                )
+                self.state.email_sent = False
                 return "send_email"
 
             # Use utility function to prepare all email parameters

--- a/src/epic_news/main.py
+++ b/src/epic_news/main.py
@@ -220,6 +220,12 @@ class ReceptionFlow(Flow[ContentState]):
         extracted_data = kickoff_flow(extraction_crew, {"user_request": self.state.user_request})
 
         dump_crewai_state(extracted_data, "EXTRACTED_INFO")
+        # The enrich task runs first, so its brief is the first task output. Store it as
+        # the working context for downstream crews; fall back to the raw request when the
+        # crew produced no usable brief (never worse than mailing the raw request).
+        tasks_output = getattr(extracted_data, "tasks_output", None) or []
+        brief = tasks_output[0].raw.strip() if tasks_output and tasks_output[0].raw else ""
+        self.state.enriched_brief = brief or self.state.user_request
         # Update the state with the extracted information
         if extracted_data:
             # Assuming extracted_data has a .pydantic attribute for the model instance

--- a/src/epic_news/main.py
+++ b/src/epic_news/main.py
@@ -1345,10 +1345,8 @@ class ReceptionFlow(Flow[ContentState]):
             # even when the request is full of places. Skipping here silently left
             # output_file at the classifier's decision.md and emailed that instead of an
             # itinerary. Fall back to the raw request, which carries the full route.
-            self.logger.warning(
-                "⚠️ No structured destination extracted; falling back to the raw user request."
-            )
-            current_inputs["destination"] = self.state.user_request
+            self.logger.warning("⚠️ No structured destination extracted; falling back to the enriched brief.")
+            current_inputs["destination"] = self.state.enriched_brief or self.state.user_request
 
         # Ensure all required template variables are provided with defaults
         required_vars = {

--- a/src/epic_news/main.py
+++ b/src/epic_news/main.py
@@ -36,13 +36,10 @@ import warnings
 from pathlib import Path
 from typing import Any, cast
 
-from crewai import Memory
 from crewai.flow import Flow, listen, or_, router, start
 from dotenv import load_dotenv
 from loguru import logger
 from pydantic import PydanticDeprecatedSince20, PydanticDeprecatedSince211, ValidationError
-
-from epic_news.config.llm_config import LLMConfig
 
 # Patch CrewAI's Pydantic schema parser to support Python 3.10 ``X | Y`` unions
 from epic_news.crews.classify.classify_crew import ClassifyCrew
@@ -179,12 +176,7 @@ class ReceptionFlow(Flow[ContentState]):
     """
 
     def __init__(self, user_request: str):
-        super().__init__(
-            memory=Memory(
-                llm=LLMConfig.get_openrouter_llm(),
-                read_only=True,
-            )
-        )
+        super().__init__()
         self._user_request = user_request
         self.logger = logger
         self.tracer = tracer

--- a/src/epic_news/models/content_state.py
+++ b/src/epic_news/models/content_state.py
@@ -102,6 +102,7 @@ class ContentState(BaseModel):
     # ============================================================================
     user_request: str = "Get the RSS Weekly Report"
     extracted_info: ExtractedInfo | None = None
+    enriched_brief: str | None = None
     attachment_file: str = ""
     current_year: str = str(datetime.datetime.now().year)
     topic_slug: str = ""
@@ -210,6 +211,12 @@ class ContentState(BaseModel):
             "target_audience",
         ]:
             inputs.setdefault(required_key, "")
+
+        # The enriched brief is a clean, complete rewrite of the whole request, so it is
+        # the best working context for any downstream crew. Prefer it; fall back to
+        # whatever context extraction produced (or the placeholder) when absent.
+        if self.enriched_brief:
+            inputs["context"] = self.enriched_brief
 
         # Return clean dictionary, removing None values but keeping required placeholders
         return {k: v for k, v in inputs.items() if v is not None}

--- a/src/epic_news/models/content_state.py
+++ b/src/epic_news/models/content_state.py
@@ -36,6 +36,13 @@ from epic_news.models.extracted_info import ExtractedInfo
 from epic_news.utils.menu_generator import MenuGenerator
 from epic_news.utils.string_utils import create_topic_slug
 
+# Upper bound on any free-text field handed to a crew. A real GLM-5.2 extraction
+# run looped `user_preferences_and_constraints` into an ~8 KB block of the same
+# sentences repeated dozens of times, which then bloated the downstream crew's
+# prompt (three copies of it) and starved its planner. Prompt instructions did not
+# constrain the model, so the cap is enforced deterministically in code instead.
+MAX_FREETEXT_CHARS = 1500
+
 
 # Constants for crew categories
 class CrewCategories:
@@ -180,6 +187,19 @@ class ContentState(BaseModel):
     objective: str = ""
     prior_interactions: str = ""
 
+    def _clean_brief_text(self, value: Any) -> str:
+        """Return clean, length-bounded free text for a crew input.
+
+        Prefer the enriched brief (a clean rewrite of the request); otherwise use the
+        given value. Always hard-cap the length so a degenerate extraction field — a
+        model looping a field into thousands of repeated characters — cannot bloat a
+        downstream crew's prompt. See MAX_FREETEXT_CHARS.
+        """
+        text = self.enriched_brief or (value if isinstance(value, str) else "") or ""
+        if len(text) > MAX_FREETEXT_CHARS:
+            text = text[:MAX_FREETEXT_CHARS].rstrip()
+        return text
+
     def to_crew_inputs(self) -> dict:
         """
         Prepares a flattened dictionary of state properties suitable for CrewAI task inputs.
@@ -196,6 +216,13 @@ class ContentState(BaseModel):
         # Flatten extracted_info if it exists
         if self.extracted_info:
             inputs.update(self._flatten_extracted_info())
+
+        # Replace the extraction's free-text preferences with the clean enriched brief
+        # (or a length-capped fallback) BEFORE menu mappings derive constraints/
+        # preferences from it, so no degenerate blob reaches any crew.
+        inputs["user_preferences_and_constraints"] = self._clean_brief_text(
+            inputs.get("user_preferences_and_constraints")
+        )
 
         # Add computed fields
         inputs.update(self._add_computed_fields())

--- a/src/epic_news/models/content_state.py
+++ b/src/epic_news/models/content_state.py
@@ -243,7 +243,7 @@ class ContentState(BaseModel):
         # the best working context for any downstream crew. Prefer it; fall back to
         # whatever context extraction produced (or the placeholder) when absent.
         if self.enriched_brief:
-            inputs["context"] = self.enriched_brief
+            inputs["context"] = self._clean_brief_text(self.enriched_brief)
 
         # Return clean dictionary, removing None values but keeping required placeholders
         return {k: v for k, v in inputs.items() if v is not None}

--- a/tests/crews/test_holiday_reporter_no_tools.py
+++ b/tests/crews/test_holiday_reporter_no_tools.py
@@ -1,0 +1,26 @@
+"""The holiday reporter agent must have no tools.
+
+A real HOLIDAY_PLANNER run crashed with::
+
+    1 validation error for HolidayPlannerReport
+    introduction  Field required [input_value={'base_currency': 'CHF', 'target_currencies': ['EUR']}]
+
+``content_formatter`` runs the final ``format_and_translate_guide`` task, which
+carries ``output_pydantic=HolidayPlannerReport``. Because that agent had tools
+(search, scrape, ExchangeRateTool), CrewAI 1.15 leaked a tool-call result — the
+ExchangeRateTool output — into ``TaskOutput.raw``, which then failed schema
+validation. The project's two-agent pattern (see crews/CLAUDE.md) requires the
+reporter to have NO tools so its output is clean structured data. It receives all
+upstream data via the sequential task context, not via live tools.
+"""
+
+from epic_news.crews.holiday_planner.holiday_planner_crew import HolidayPlannerCrew
+
+
+def test_content_formatter_reporter_has_no_tools():
+    formatter = HolidayPlannerCrew().content_formatter()
+    assert not formatter.tools, (
+        "content_formatter runs the output_pydantic=HolidayPlannerReport task; giving it "
+        "tools lets a tool-call result (e.g. ExchangeRateTool) leak into TaskOutput.raw and "
+        "fail schema validation. Reporter agents must have no tools."
+    )

--- a/tests/crews/test_information_extraction_enrich.py
+++ b/tests/crews/test_information_extraction_enrich.py
@@ -1,0 +1,36 @@
+"""InformationExtractionCrew runs an enrich task before extraction, and the
+extraction task consumes the enriched brief as context."""
+
+from epic_news.crews.information_extraction.information_extraction_crew import (
+    InformationExtractionCrew,
+)
+from epic_news.models.extracted_info import ExtractedInfo
+
+
+def test_crew_has_two_agents_and_two_tasks():
+    crew = InformationExtractionCrew().crew()
+    assert len(crew.agents) == 2
+    assert len(crew.tasks) == 2
+
+
+def test_enrich_runs_first_and_extraction_consumes_it():
+    crew = InformationExtractionCrew().crew()
+    enrich_task, extract_task = crew.tasks[0], crew.tasks[1]
+
+    # Enrich task emits plain text (the brief), not the structured model.
+    assert enrich_task.output_pydantic is None
+    # Extraction task still produces ExtractedInfo, and now reads the enrich task.
+    assert extract_task.output_pydantic is ExtractedInfo
+    assert extract_task.context, "extraction task must consume the enrich task as context"
+    assert enrich_task in extract_task.context
+
+
+def test_faithfulness_guard_is_present_in_config():
+    """The 'never invent' constraint is the core safety property — lock it in so a
+    future edit can't quietly drop it. Real LLM faithfulness is checked manually
+    (see the plan's end-to-end verification), not in CI."""
+    ie = InformationExtractionCrew()
+    agent_backstory = ie.prompt_enricher_agent().backstory.lower()
+    task_desc = ie.enrich_request_task().description.lower()
+    assert "never invent" in agent_backstory
+    assert "do not" in task_desc and "invent" in task_desc

--- a/tests/flows/test_extract_info_enriched_brief.py
+++ b/tests/flows/test_extract_info_enriched_brief.py
@@ -1,0 +1,41 @@
+"""extract_info stores the enriched brief on state, falling back to the raw request."""
+
+import epic_news.main as main_mod
+from epic_news.main import ReceptionFlow
+
+
+class _TaskOutput:
+    def __init__(self, raw):
+        self.raw = raw
+
+
+class _Result:
+    def __init__(self, tasks_output, pydantic=None):
+        self.tasks_output = tasks_output
+        self.pydantic = pydantic
+
+
+def _flow(monkeypatch, result):
+    flow = ReceptionFlow(user_request="raw messy request")
+    flow.state.user_request = "raw messy request"
+    monkeypatch.setattr(main_mod, "kickoff_flow", lambda *a, **k: result)
+    monkeypatch.setattr(main_mod, "dump_crewai_state", lambda *a, **k: None)
+    return flow
+
+
+def test_captures_enriched_brief(monkeypatch):
+    result = _Result([_TaskOutput("Clean brief"), _TaskOutput("{}")], pydantic=None)
+    flow = _flow(monkeypatch, result)
+
+    flow.extract_info()
+
+    assert flow.state.enriched_brief == "Clean brief"
+
+
+def test_falls_back_to_raw_request_when_no_brief(monkeypatch):
+    result = _Result([], pydantic=None)  # crew produced no task outputs
+    flow = _flow(monkeypatch, result)
+
+    flow.extract_info()
+
+    assert flow.state.enriched_brief == "raw messy request"

--- a/tests/flows/test_holiday_no_destination.py
+++ b/tests/flows/test_holiday_no_destination.py
@@ -1,0 +1,72 @@
+"""Regression: a multi-stop road-trip request produced no report and emailed the
+classifier's decision.md instead.
+
+A real run of a Montreux→Montpellier→Anglet→Poitiers→Bourges request had extraction
+leave ``destination_location`` (and origin/duration/traveler) ``None`` — the request
+describes a *route*, not a single destination. ``generate_holiday_plan`` then silently
+early-returned, leaving ``state.output_file`` at ``output/classify/decision.md``, and
+``send_email`` mailed that classification JSON as if it were the itinerary.
+
+Two guarantees are locked in here:
+  1. Missing ``destination`` falls back to the raw request so the crew still runs.
+  2. ``send_email`` refuses to deliver the classifier decision as a report.
+"""
+
+from collections import defaultdict
+from pathlib import Path
+
+import epic_news.main as main_mod
+from epic_news.main import CLASSIFY_DECISION_FILE, ReceptionFlow
+
+
+def _stub_crew_internals(monkeypatch):
+    monkeypatch.setattr(
+        main_mod, "kickoff_flow", lambda *a, **k: type("O", (), {"raw": "{}", "pydantic": None})()
+    )
+    monkeypatch.setattr(main_mod, "dump_crewai_state", lambda *a, **k: None)
+    monkeypatch.setattr(main_mod, "load_or_parse_model", lambda *a, **k: object())
+    monkeypatch.setattr(main_mod, "render_and_write_html", lambda crew, model, path: Path(path))
+
+
+def test_holiday_falls_back_to_raw_request_when_no_destination(monkeypatch):
+    flow = ReceptionFlow(user_request="x")
+    flow.state.user_request = "road trip through Montpellier, Anglet, Poitiers, Bourges"
+    _stub_crew_internals(monkeypatch)
+
+    # Extraction left every structured travel field empty -> no "destination" key.
+    monkeypatch.setattr(
+        type(flow.state), "to_crew_inputs", lambda self: defaultdict(str, {"topic": "vacation"})
+    )
+
+    captured = {}
+    real_kickoff = main_mod.kickoff_flow
+
+    def capture_kickoff(crew, inputs, *a, **k):
+        captured.update(inputs)
+        return real_kickoff(crew, inputs, *a, **k)
+
+    monkeypatch.setattr(main_mod, "kickoff_flow", capture_kickoff)
+
+    flow.generate_holiday_plan()
+
+    # The crew actually ran and the itinerary is the report, not decision.md.
+    assert flow.state.output_file == "output/holiday/itinerary.html"
+    assert captured.get("destination"), "destination must be populated for the crew to run"
+    assert "Montpellier" in captured["destination"]
+
+
+def test_send_email_refuses_to_deliver_classification_decision(monkeypatch):
+    monkeypatch.setenv("EPIC_ENABLE_EMAIL", "true")
+    flow = ReceptionFlow(user_request="x")
+    flow.state.sendto = "someone@example.com"
+    flow.state.output_file = CLASSIFY_DECISION_FILE  # report never generated
+    flow.state.email_sent = False
+
+    def must_not_send(**_kw):  # pragma: no cover - must not be reached
+        raise AssertionError("must not email the classifier decision as a report")
+
+    monkeypatch.setattr(main_mod, "send_report_email", must_not_send)
+
+    flow.send_email()
+
+    assert flow.state.email_sent is False

--- a/tests/flows/test_holiday_no_destination.py
+++ b/tests/flows/test_holiday_no_destination.py
@@ -28,9 +28,12 @@ def _stub_crew_internals(monkeypatch):
     monkeypatch.setattr(main_mod, "render_and_write_html", lambda crew, model, path: Path(path))
 
 
-def test_holiday_falls_back_to_raw_request_when_no_destination(monkeypatch):
+def test_holiday_falls_back_to_enriched_brief_when_no_destination(monkeypatch):
     flow = ReceptionFlow(user_request="x")
-    flow.state.user_request = "road trip through Montpellier, Anglet, Poitiers, Bourges"
+    flow.state.user_request = "raw messy request through Montpellier, Anglet, Poitiers, Bourges"
+    # The enrich step produced a clean brief; the fallback must prefer it over the raw
+    # request so the crew gets the clean text, not the 8 KB raw blob.
+    flow.state.enriched_brief = "Family road trip: Montpellier, Anglet, Poitiers, Bourges"
     _stub_crew_internals(monkeypatch)
 
     # Extraction left every structured travel field empty -> no "destination" key.
@@ -52,7 +55,8 @@ def test_holiday_falls_back_to_raw_request_when_no_destination(monkeypatch):
     # The crew actually ran and the itinerary is the report, not decision.md.
     assert flow.state.output_file == "output/holiday/itinerary.html"
     assert captured.get("destination"), "destination must be populated for the crew to run"
-    assert "Montpellier" in captured["destination"]
+    # The fallback prefers the clean enriched brief over the raw request.
+    assert captured["destination"] == "Family road trip: Montpellier, Anglet, Poitiers, Bourges"
 
 
 def test_send_email_refuses_to_deliver_classification_decision(monkeypatch):

--- a/tests/models/test_content_state_enriched_context.py
+++ b/tests/models/test_content_state_enriched_context.py
@@ -1,0 +1,19 @@
+"""to_crew_inputs must surface the enriched brief as the downstream `context`."""
+
+from epic_news.models.content_state import ContentState
+
+
+def test_enriched_brief_becomes_context():
+    state = ContentState()
+    state.user_request = "raw messy request"
+    state.enriched_brief = "Clean family road-trip brief with all four cities"
+    inputs = state.to_crew_inputs()
+    assert inputs["context"] == "Clean family road-trip brief with all four cities"
+
+
+def test_no_enriched_brief_keeps_default_context():
+    state = ContentState()
+    state.user_request = "raw messy request"
+    inputs = state.to_crew_inputs()
+    # Unchanged behaviour: context stays the empty-string placeholder when nothing set it.
+    assert inputs.get("context", "") == ""

--- a/tests/models/test_content_state_enriched_context.py
+++ b/tests/models/test_content_state_enriched_context.py
@@ -1,6 +1,11 @@
-"""to_crew_inputs must surface the enriched brief as the downstream `context`."""
+"""to_crew_inputs must surface the enriched brief as the downstream `context`, and
+must never leak a degenerate (looped/oversized) extraction field to a crew."""
 
-from epic_news.models.content_state import ContentState
+from epic_news.models.content_state import MAX_FREETEXT_CHARS, ContentState
+from epic_news.models.extracted_info import ExtractedInfo
+
+# A real GLM-5.2 extraction looped this field; simulate the degeneracy.
+DEGENERATE_BLOB = "Road trip by car; hotels booked; family of 3. " * 2000  # ~90 KB
 
 
 def test_enriched_brief_becomes_context():
@@ -17,3 +22,29 @@ def test_no_enriched_brief_keeps_default_context():
     inputs = state.to_crew_inputs()
     # Unchanged behaviour: context stays the empty-string placeholder when nothing set it.
     assert inputs.get("context", "") == ""
+
+
+def test_degenerate_preferences_replaced_by_enriched_brief():
+    state = ContentState()
+    state.user_request = "raw"
+    state.enriched_brief = "Clean brief: family road trip, 4 stops"
+    state.extracted_info = ExtractedInfo(
+        main_subject_or_activity="trip", user_preferences_and_constraints=DEGENERATE_BLOB
+    )
+    inputs = state.to_crew_inputs()
+    # The looped blob never reaches a crew: preferences fields become the clean brief.
+    for key in ("user_preferences_and_constraints", "constraints", "preferences"):
+        assert inputs[key] == "Clean brief: family road trip, 4 stops"
+        assert len(inputs[key]) <= MAX_FREETEXT_CHARS
+
+
+def test_freetext_hard_capped_when_no_enriched_brief():
+    state = ContentState()
+    state.user_request = "raw"
+    state.extracted_info = ExtractedInfo(
+        main_subject_or_activity="trip", user_preferences_and_constraints=DEGENERATE_BLOB
+    )
+    inputs = state.to_crew_inputs()
+    # No brief to prefer, but the cap still bounds every derived free-text field.
+    for key in ("user_preferences_and_constraints", "constraints", "preferences"):
+        assert len(inputs[key]) <= MAX_FREETEXT_CHARS

--- a/uv.lock
+++ b/uv.lock
@@ -1956,7 +1956,7 @@ wheels = [
 
 [[package]]
 name = "langfuse"
-version = "4.13.2"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backoff" },
@@ -1968,9 +1968,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "wrapt" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/00/16324f1c0d244fee3c4e4ac00e8a422f1afb8873e963182dac7fbf8b34e8/langfuse-4.13.2.tar.gz", hash = "sha256:4484c5d949dd1c5cabab74c179c7e5c19be203940852bf90d1ba5870215eac6a", size = 362128, upload-time = "2026-07-08T15:54:07.889Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ae/40/752661e4376dcaa73bf839703296530d91807e90e219e1fc0d24c5460bc2/langfuse-4.14.0.tar.gz", hash = "sha256:31b875c8d09eee39c558584b9424bbd5ed014965c5944c4528a37947ae4b7787", size = 363802, upload-time = "2026-07-10T11:33:39.153Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/67/40641c2e7897990d1264d16037788c5cc1adb5c967d0f04bcf56c6119336/langfuse-4.13.2-py3-none-any.whl", hash = "sha256:b5b48b02438835316e5bf61266b89faaff0687fb8ebd765d62d5a489401dc56a", size = 636577, upload-time = "2026-07-08T15:54:08.967Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c7/ca0f591e1184415ffcd920a4107f3d2638ab5af7ff7e498d99a9b8b2bb13/langfuse-4.14.0-py3-none-any.whl", hash = "sha256:632b74abfa14d9ad3dccbe3322bf7e11b0dce9be0de451b0d134db9bff246d44", size = 638356, upload-time = "2026-07-10T11:33:37.419Z" },
 ]
 
 [[package]]
@@ -2018,7 +2018,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.91.1"
+version = "1.92.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -2034,9 +2034,10 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a7/70/1b419158085e0cc1615642dd62c7a5d4c3254db3de77df65dade3b25165b/litellm-1.91.1.tar.gz", hash = "sha256:49a24593df7e37262c52243a8e07572d451d37c100aa1b1f347d80d501d2e386", size = 14872532, upload-time = "2026-07-08T23:07:04.559Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/ea/5522be7e0dbcaa7c3fddfd2834f387c6e8eab47c0cc65f2a74657c815af7/litellm-1.92.0.tar.gz", hash = "sha256:773adf5503ee1793289689c899394a83df8122993760d9acd782e32aa798db9d", size = 15098143, upload-time = "2026-07-12T01:15:59.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/52/166a934d194afcff2a7ec4e1928f1865504ade2e26f62e24d49aaec400d1/litellm-1.91.1-py3-none-any.whl", hash = "sha256:bf8e3d23cddf0eb4c05714dffcaafd8a944adf0f9c9b01c6c863b2637309de2e", size = 16670790, upload-time = "2026-07-08T23:07:01.151Z" },
+    { url = "https://files.pythonhosted.org/packages/10/34/1671376f228443330471416e24ee51bc8364c0ae6155d4ec6217b70a4753/litellm-1.92.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:437a0e403136996430795ead76502103dcf74769b6909e12d3e2511061ea8ff8", size = 19291560, upload-time = "2026-07-12T01:15:54.66Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/4f/141cf1162eeee762fc839c335e3f78fc309a65f2385023479a20b09e680a/litellm-1.92.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:8f03047a73154f33c2733899e4bf9b5ed129e2e345caa305895a318452e4a807", size = 19289770, upload-time = "2026-07-12T01:15:57.136Z" },
 ]
 
 [[package]]
@@ -2940,24 +2941,17 @@ wheels = [
 
 [[package]]
 name = "pyarrow"
-version = "24.0.0"
+version = "25.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/91/13/13e1069b351bdc3881266e11147ffccf687505dbb0ea74036237f5d454a5/pyarrow-24.0.0.tar.gz", hash = "sha256:85fe721a14dd823aca09127acbb06c3ca723efbd436c004f16bca601b04dcc83", size = 1180261, upload-time = "2026-04-21T10:51:25.837Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/27/f3/95428098d1fa7d04432fb750eed06b41304c2f6a5d3319985e64db2d9d41/pyarrow-25.0.0.tar.gz", hash = "sha256:d2d697008b5ec06d75952ef260c2e9a8a0f6ccfce24266c04c9c8ade927cb3b4", size = 1199181, upload-time = "2026-07-10T08:29:50.116Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6f/d3/a1abf004482026ddc17f4503db227787fa3cfe41ec5091ff20e4fea55e57/pyarrow-24.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:02b001b3ed4723caa44f6cd1af2d5c86aa2cf9971dacc2ffa55b21237713dfba", size = 34976759, upload-time = "2026-04-21T10:48:07.258Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/4a/34f0a36d28a2dd32225301b79daad44e243dc1a2bb77d43b60749be255c4/pyarrow-24.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:04920d6a71aabd08a0417709efce97d45ea8e6fb733d9ca9ecffb13c67839f68", size = 36658471, upload-time = "2026-04-21T10:48:13.347Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/78/543b94712ae8bb1a6023bcc1acf1a740fbff8286747c289cd9468fced2a5/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:a964266397740257f16f7bb2e4f08a0c81454004beab8ff59dd531b73610e9f2", size = 45675981, upload-time = "2026-04-21T10:48:20.201Z" },
-    { url = "https://files.pythonhosted.org/packages/84/9f/8fb7c222b100d314137fa40ec050de56cd8c6d957d1cfff685ce72f15b17/pyarrow-24.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f066b179d68c413374294bc1735f68475457c933258df594443bb9d88ddc2a0", size = 48859172, upload-time = "2026-04-21T10:48:27.541Z" },
-    { url = "https://files.pythonhosted.org/packages/a7/d3/1ea72538e6c8b3b475ed78d1049a2c518e655761ea50fe1171fc855fcab7/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1183baeb14c5f587b1ec52831e665718ce632caab84b7cd6b85fd44f96114495", size = 49385733, upload-time = "2026-04-21T10:48:34.7Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/be/c3d8b06a1ba35f2260f8e1f771abbee7d5e345c0937aab90675706b1690a/pyarrow-24.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:806f24b4085453c197a5078218d1ee08783ebbba271badd153d1ae22a3ee804f", size = 51934335, upload-time = "2026-04-21T10:48:42.099Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/62/89e07a1e7329d2cde3e3c6994ba0839a24977a2beda8be6005ea3d860b99/pyarrow-24.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:e4505fc6583f7b05ab854934896bcac8253b04ac1171a77dfb73efef92076d91", size = 27271748, upload-time = "2026-04-21T10:49:42.532Z" },
-    { url = "https://files.pythonhosted.org/packages/17/1a/cff3a59f80b5b1658549d46611b67163f65e0664431c076ad728bf9d5af4/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:1a4e45017efbf115032e4475ee876d525e0e36c742214fbe405332480ecd6275", size = 35238554, upload-time = "2026-04-21T10:48:48.526Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/99/cce0f42a327bfef2c420fb6078a3eb834826e5d6697bf3009fe11d2ad051/pyarrow-24.0.0-cp313-cp313t-macosx_12_0_x86_64.whl", hash = "sha256:7986f1fa71cee060ad00758bcc79d3a93bab8559bf978fab9e53472a2e25a17b", size = 36782301, upload-time = "2026-04-21T10:48:55.181Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/66/8e560d5ff6793ca29aca213c53eec0dd482dd46cb93b2819e5aab52e4252/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d3e0b61e8efb24ed38898e5cdc5fffa9124be480008d401a1f8071500494ae42", size = 45721929, upload-time = "2026-04-21T10:49:03.676Z" },
-    { url = "https://files.pythonhosted.org/packages/27/0c/a26e25505d030716e078d9f16eb74973cbf0b33b672884e9f9da1c83b871/pyarrow-24.0.0-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:55a3bc1e3df3b5567b7d27ef551b2283f0c68a5e86f1cd56abc569da4f31335b", size = 48825365, upload-time = "2026-04-21T10:49:11.714Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/eb/771f9ecb0c65e73fe9dccdd1717901b9594f08c4515d000c7c62df573811/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:641f795b361874ac9da5294f8f443dfdbee355cf2bd9e3b8d97aaac2306b9b37", size = 49451819, upload-time = "2026-04-21T10:49:21.474Z" },
-    { url = "https://files.pythonhosted.org/packages/48/da/61ae89a88732f5a785646f3ec6125dbb640fa98a540eb2b9889caa561403/pyarrow-24.0.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8adc8e6ce5fccf5dc707046ae4914fd537def529709cc0d285d37a7f9cd442ca", size = 51909252, upload-time = "2026-04-21T10:49:31.164Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1a/8dd5cafab7b66573fa91c03d06d213356ad4edd71813aa75e08ce2b3a844/pyarrow-24.0.0-cp313-cp313t-win_amd64.whl", hash = "sha256:9b18371ad2f44044b81a8d23bc2d8a9b6a6226dca775e8e16cfee640473d6c5d", size = 27388127, upload-time = "2026-04-21T10:49:37.334Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/c8/098ce17d778fd9d29e40bb8c5f19a40cc90c3f0b46c9057b0d7993f42f54/pyarrow-25.0.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8831a3ba52fa7cdb78d368d968b1dcd06171e6dff5461e16d90de91d371e47bc", size = 35844549, upload-time = "2026-07-10T08:27:37.956Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/66/24c28877219abf6263d909b1592c97ff82c59f13a59acbed11fc87c0654f/pyarrow-25.0.0-cp313-cp313-macosx_12_0_x86_64.whl", hash = "sha256:5f4bacb60f91dd2fca6c52f1b9a0012cd090e0294f1f781dc1881a247a352f8e", size = 37610397, upload-time = "2026-07-10T08:27:43.803Z" },
+    { url = "https://files.pythonhosted.org/packages/53/55/6d1d5f5aff317ec5de9421594679ed51ed828fe7e2ce209327f819d801e4/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:59516c822d5fd8e544aaa0dfe72f36fed5d4c24ea8390aab1bcd31d7e959c6be", size = 46841701, upload-time = "2026-07-10T08:27:49.741Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/5d/f790fb6965ab54c9da0dda7856abc75fd0d7648d865f8d603c111d203a64/pyarrow-25.0.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:6f9dbd83e91c239a1f5ee7ce13f108b5f6c0efbe40a4375260d8f08b43ad05e9", size = 50090118, upload-time = "2026-07-10T08:27:56.051Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/8c/faf025357ebf31bc96777f234277aa31e2aeca6dd4ecaa391f29085473c2/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:18dcc8cc50b5e72eae6fcbfc6c8776c21a007176b27a3cdec5c2f5bcf126708d", size = 49945559, upload-time = "2026-07-10T08:28:01.927Z" },
+    { url = "https://files.pythonhosted.org/packages/07/a1/bd051871708ea99a5e0fc711926c26c6f2c6d0130c7aaac8093e34998af6/pyarrow-25.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4ec1895a87aa834c3b99b7a1e758747eb8bb57f922b32c0e0fa04afb8d6998b1", size = 53114238, upload-time = "2026-07-10T08:28:08.594Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/31/737f0c3cffcd6af647849477d1dd68045deac2e3963c3f9f211bedc48540/pyarrow-25.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:77c8d1ae46a44b4006e8db1cc977bbcc6ce4873c92f74137d68e45503b97fb18", size = 27861162, upload-time = "2026-07-10T08:28:12.975Z" },
 ]
 
 [[package]]
@@ -4081,11 +4075,11 @@ wheels = [
 
 [[package]]
 name = "tzdata"
-version = "2026.2"
+version = "2026.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/ff/5a28bdfd8c3ebec42564ac7d0e54ca3db65044a9314a97f9564fa7a1e926/tzdata-2026.3.tar.gz", hash = "sha256:4a1518b8993086a7982523e071643f3c0e5f213e75b21318e78bcabfff9d1415", size = 198674, upload-time = "2026-07-10T08:50:37.887Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/6d/b53b99a9f2766d095985947a5782f1702cabb129a34f7a802d7197af832f/tzdata-2026.3-py2.py3-none-any.whl", hash = "sha256:dc096730c87af6cab1b171c9d532be840741ff5d459015e7f6947bd7d7e54931", size = 348168, upload-time = "2026-07-10T08:50:36.46Z" },
 ]
 
 [[package]]
@@ -4213,7 +4207,7 @@ wheels = [
 
 [[package]]
 name = "virtualenv"
-version = "21.6.0"
+version = "21.6.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -4221,9 +4215,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "python-discovery" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/74/65/ec1d92091671e6407d3e7c1f5801413bb7b2b57630a50cae7750456ba0ed/virtualenv-21.6.0.tar.gz", hash = "sha256:e18a4d750f2b64dea73e72ffde3922f3c52365fabdc8157ebd3da20d031c4734", size = 5526111, upload-time = "2026-07-06T22:49:56.972Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/d9/b477fddb68840b570af8b22afe9b035cbc277b5fb7b33dea390617a8b10f/virtualenv-21.6.1.tar.gz", hash = "sha256:15f978b7cd329f24855ff4a0c4b4899cc7678589f49adbdcbbb4d3232e641128", size = 5526620, upload-time = "2026-07-10T19:33:53.312Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b8/e7/2fbd0cc1653c53eed8f10670538bb547de2b3e37aacad283faa82a71094b/virtualenv-21.6.0-py3-none-any.whl", hash = "sha256:bce9d097950fef9d81129b333babfb7767072850c2f1acce0ec536708401bfd1", size = 5506216, upload-time = "2026-07-06T22:49:54.941Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/7c/4e7225d46d634a0d8d534dd8a6ce0c319d09b4d0cf0337eb314ca4789d8c/virtualenv-21.6.1-py3-none-any.whl", hash = "sha256:afe991df855715a2b2f60edfcc0107ef95a79fdfd8cb4cdaa71603d1c12e463b", size = 5506392, upload-time = "2026-07-10T19:33:51.629Z" },
 ]
 
 [[package]]
@@ -4319,20 +4313,28 @@ wheels = [
 
 [[package]]
 name = "websockets"
-version = "16.0"
+version = "16.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/02/b9a097e1e16fee4e2fd1ec8c39f6a9c5d6257bae8fa12640caf869f54436/websockets-16.1.tar.gz", hash = "sha256:299468cbe42e2b9981134c7c51d99387d8a7bf562b00183b3eec53f882846dad", size = 182530, upload-time = "2026-07-10T06:32:57.734Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
-    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
-    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
-    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
-    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/63/df158b155420b566f025e75613424ad9649a24bcb0e9f259321ab3d58bea/websockets-16.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:b0232ed141cec3df2af5a3959a071c51f40036336b0d37e17faf9ef52fc73e47", size = 179791, upload-time = "2026-07-10T06:31:33.108Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cf/00fe9414dfeafa6fe54eae9f5716c8c8e9ac59d192be3b893c096d395846/websockets-16.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:a71b73d143991714144e159f767b698f03c4a70b8a65ae1733b650cff488045b", size = 177472, upload-time = "2026-07-10T06:31:34.522Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/76/b10633424d40681b4e892ffd08ca5226322b2426e62d4ab71eae484c3a32/websockets-16.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:187323204c3b2fc465e8fc2609e60437c521790cb9c1acb49c4c452a33e57f37", size = 177737, upload-time = "2026-07-10T06:31:35.964Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/61/d3bb03b2229bb1afd72008742d586cf1ea240dce64dd48c71c8c7fd3294c/websockets-16.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9dba74233c8c3ce368850818c98354dad2570f57231b3fd3bd00d7aa57628881", size = 187403, upload-time = "2026-07-10T06:31:37.496Z" },
+    { url = "https://files.pythonhosted.org/packages/26/16/cc2e80478f688fc3c39c67dc1fac6a0783858058914ebc2489917462cb42/websockets-16.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:63339bc8c63c86a463177775cb7c677691f5bcfac7b3b2f01b286d42acd41600", size = 188639, upload-time = "2026-07-10T06:31:38.86Z" },
+    { url = "https://files.pythonhosted.org/packages/15/d6/ad87b2507e57de1cbf897a56c963f2925962ed5e85fbe06aaa83ced27acd/websockets-16.1-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:23e545ea8ae4263e37cdfd4e22a217f519e48e432728bc461185bbf585f38a83", size = 190078, upload-time = "2026-07-10T06:31:40.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/1a/5b37b3fd335d5811f29fc829f2646a3e6d1463a4bf09c3100708684c766e/websockets-16.1-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:2237081454846fb40403a80ba86d82e2038b9c45865ab96af0abe7d002a91045", size = 189267, upload-time = "2026-07-10T06:31:41.523Z" },
+    { url = "https://files.pythonhosted.org/packages/42/98/06afc33e9450d4230f94c664db78875d90f5f6a5fb77f0bc6ec15ae74e1c/websockets-16.1-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5f5218de1ed047385ca53744caba9435d65f75d008364970a3fae95a05812cf9", size = 188022, upload-time = "2026-07-10T06:31:42.838Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/42fef5d5887c18cf2d148b02debf56cecb9cfbffc68027cde9b12c8f432c/websockets-16.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:75c98e3920039d0edff03b74478ada504b7ce3a1bc406db2cabfca84320f7baf", size = 185435, upload-time = "2026-07-10T06:31:44.219Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/9b/8021c133add5fe40ed40312553a6cd1408c069d7efe3444ad483d4973ed3/websockets-16.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1facd189d8190af30487a55b4c3688484dd50801628a3b5b2ccd26db08e67057", size = 188080, upload-time = "2026-07-10T06:31:45.986Z" },
+    { url = "https://files.pythonhosted.org/packages/69/54/1e37384f395eaa127383aab15c1c45e200890a7d7b99db5c312233d193e0/websockets-16.1-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:cc0c6a6eef613c7da32d4fb068f82ef834b58134f6a16b54e6c1e5bf9529ab3d", size = 186678, upload-time = "2026-07-10T06:31:47.449Z" },
+    { url = "https://files.pythonhosted.org/packages/68/79/1caeacab5bc2081e4519288d248bc8bd2de30652e6eaa94be6be09a1fe5b/websockets-16.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:ad9411eded8988b879be6038206698bf7106c85a78f642c004485bcb95be17eb", size = 188554, upload-time = "2026-07-10T06:31:48.886Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/83/b3dca5fad71487b726e31cb0acf56f226792c1cc34e6ab18cbf146bd2d74/websockets-16.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:cd68f0914f3b64694895bc5e9b14e8b447e41d7bf5ffaf989bb8dcb5e2dfdce7", size = 186109, upload-time = "2026-07-10T06:31:50.508Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/0b/8f246c3712f07f207b52ea5fb47f3b2b66fafec7303162644c74aed51c6a/websockets-16.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:fef2debfe7f7ebdda12176f26166f95b7af17af05ba06150fcf889032e0213e9", size = 187061, upload-time = "2026-07-10T06:31:51.861Z" },
+    { url = "https://files.pythonhosted.org/packages/47/eb/27d6c92a01696b6495386af4fc941d7d0a13f2eab2bf9c336111d7321491/websockets-16.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a3cd6c9b798218798f4bb7b2e71c38f0e744bb94ca537b13376f88019d46384d", size = 187347, upload-time = "2026-07-10T06:31:53.246Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/d5/eeee439921f55d5eaeabcea18d0f7ce32cdc39cb8fc1e185431a094c5c7b/websockets-16.1-cp313-cp313-win32.whl", hash = "sha256:84c170c6869633536921e4474b1cce7254c0c9b0053ef5725f966cee47e718e4", size = 180149, upload-time = "2026-07-10T06:31:55.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/03/971e98d4a4864cf263f9e94c5b2b7c9a9b7682d77bfbba4e732c55ee85a9/websockets-16.1-cp313-cp313-win_amd64.whl", hash = "sha256:bef52d327d70fa75dad93ee61ea2cb1d1489aca9f35c188833563f5a3b4df0a5", size = 180458, upload-time = "2026-07-10T06:31:56.767Z" },
+    { url = "https://files.pythonhosted.org/packages/66/58/bd83247f39ddc26ffc2c24eb05087a3b749e00cb4509fc6d19daa23c8495/websockets-16.1-py3-none-any.whl", hash = "sha256:c5149dfe490ec7e5ee5dbf624c642fb725f93a5575c7f00ab594ca9eddb8dd81", size = 174031, upload-time = "2026-07-10T06:32:56.079Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Disable CrewAI agent `reasoning` (`reasoning=True` → `reasoning=False`) across 15 crews.
- Remove CrewAI `Memory` from `ReceptionFlow`: it was configured with a LanceDB store but **no embedder**, which crashed `crewai flow kickoff` with `exit status 1`. This project uses real-time retrieval, not RAG/memory.
- Regenerate `.serena/project.yml` from the current upstream Serena template.

## Why

The flow was dying at kickoff with a generic `Command '['uv', 'run', 'kickoff']' returned non-zero exit status 1`. The root cause was the `Memory(storage='lancedb', embedder=None)` config on the flow — LanceDB needs an embedder to function. Memory isn't used by design in this project.

## Notes

Local-only files were intentionally excluded from this PR: the personal default-request sentinel block in `main.py` and `docker-compose.override.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174YSPJ8Uc2wtheHmd56vaE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added prompt enrichment to clarify requests while preserving the original facts and language.
  * Improved support for multi-stop travel requests, including ordered destinations and itinerary generation when structured destinations are unavailable.
  * Added safeguards to limit oversized free-text inputs and maintain reliable downstream processing.

* **Bug Fixes**
  * Prevented classification decision files from being sent as final reports.
  * Reduced tool-related artifacts in holiday plan output for cleaner, valid results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->