### PR TITLE
chore(release): v3.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Epic News are documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [3.4.0] — 2026-07-12
+
+A prompt-enrichment release. The raw user request is now rewritten into a clean, complete brief **before** structured extraction, and that brief becomes the working `context` every downstream crew sees — with deterministic length caps so a degenerate LLM rewrite can no longer bloat a crew's prompt. Ships alongside a batch of flow and extraction reliability fixes.
+
+### Added
+- **Prompt enrichment in `InformationExtractionCrew`**: the user request is enriched into a clean rewrite (`enriched_brief`) before fields are extracted, captured into flow state during extraction, and surfaced as the downstream `context` for every crew. A clean, complete rewrite of the whole request is a better working context than the raw message.
+
+### Fixed
+- **Free-text crew inputs are now length-capped deterministically** (`MAX_FREETEXT_CHARS = 1500`): a real extraction run looped `user_preferences_and_constraints` into an ~8 KB block of the same sentences repeated dozens of times, bloating the downstream crew's prompt and starving its planner. Both `user_preferences_and_constraints` and the enriched brief handed to crews via `context` now pass through the same cap (#156).
+- **Multi-stop trips are parsed correctly**, and the extraction no longer repeats the user's preferences back into its own output.
+- **The holiday reporter agent no longer carries tools** — it only renders its report, so no action traces leak into the output (two-agent researcher/reporter split).
+- **The classifier's routing decision is no longer emailed as a holiday report** — a misrouted flow branch was shipping the classifier's output as the final report.
+- **CrewAI agent `reasoning` disabled across 15 crews**, and **CrewAI `Memory` removed from `ReceptionFlow`** — the flow was configured with a LanceDB memory store but no embedder, which crashed `crewai flow kickoff` with a generic `exit status 1`. The project uses real-time retrieval, not RAG/memory (#156).
+
+### Changed
+- Refreshed locked dependencies: langfuse 4.14.0, litellm 1.92.0, pyarrow 25.0.0, and related transitive pins.
+
 ## [3.3.5] — 2026-07-10
 
 A deep-research reliability fix. A single omitted field from the report-writing LLM no longer discards the entire (~9-minute) research run.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 
 [project]
 name = "epic_news"
-version = "3.3.5"
+version = "3.4.0"
 description = "epic-news using crewAI"
 authors = [{ name = "Your Name", email = "you@example.com" }]
 requires-python = ">=3.13,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -975,7 +975,7 @@ wheels = [
 
 [[package]]
 name = "epic-news"
-version = "3.3.5"
+version = "3.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Release v3.4.0

Version bump `3.3.5` → `3.4.0` (minor — new feature). Full entry in `CHANGELOG.md`.

### Highlights

- **Added**: prompt enrichment in `InformationExtractionCrew` — the raw request is rewritten into a clean `enriched_brief` before extraction and surfaced as the downstream `context` for every crew.
- **Fixed**: deterministic free-text caps (`MAX_FREETEXT_CHARS`), multi-stop trip parsing, holiday reporter tool removal, classifier-decision email misroute, agent `reasoning` disabled across 15 crews + CrewAI `Memory` removed from the flow (#156).
- **Changed**: dependency refresh — langfuse 4.14.0, litellm 1.92.0, pyarrow 25.0.0.

On merge: tag `v3.4.0` on the merge commit → `gh release` → Docker publishes on the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174YSPJ8Uc2wtheHmd56vaE
