### PR TITLE
fix(llm): retry LLM.call on empty Gemini thought-only responses

### DIFF
--- a/src/epic_news/config/llm_config.py
+++ b/src/epic_news/config/llm_config.py
@@ -4,8 +4,39 @@ import os
 
 from crewai import LLM
 from dotenv import load_dotenv
+from loguru import logger
 
 load_dotenv()
+
+
+def _is_empty_llm_response(result: object) -> bool:
+    """True when an ``LLM.call`` result carries no usable text.
+
+    CrewAI's ReAct path returns the model's answer as a ``str``; an empty/blank
+    string or ``None`` means the provider produced no output text for this turn.
+    """
+    if result is None:
+        return True
+    return isinstance(result, str) and not result.strip()
+
+
+def _call_with_empty_retry(call_fn, max_retries: int, model: str = "?"):
+    """Invoke ``call_fn`` and re-invoke it while it returns an empty LLM response.
+
+    Retries at most ``max_retries`` times, then returns the last (possibly empty)
+    result so the caller's normal empty-handling still applies. Extracted from the
+    ``LLM.call`` patch so the retry loop is unit-testable without live calls.
+    """
+    result = call_fn()
+    attempts = 0
+    while attempts < max_retries and _is_empty_llm_response(result):
+        attempts += 1
+        logger.warning(
+            f"Empty response from LLM '{model}' (likely Gemini thought-only turn); "
+            f"retrying {attempts}/{max_retries}"
+        )
+        result = call_fn()
+    return result
 
 
 def _patch_anthropic_detection_for_openrouter() -> None:
@@ -70,8 +101,45 @@ def _force_react_tool_calling() -> None:
     LLM._react_tool_calling_forced = True  # type: ignore[attr-defined]
 
 
+def _patch_llm_retry_on_empty() -> None:
+    """Retry ``LLM.call`` when a provider returns empty content.
+
+    ``gemini/gemini-3.5-flash`` intermittently returns a *thought-only* response on
+    CrewAI ReAct steps: the generated tokens land in a thinking block carrying a
+    ``thought_signature`` and ``message.content`` comes back ``None`` (``finish_reason``
+    is still ``stop``, so it is not a length/budget cut-off). CrewAI's
+    ``_validate_and_finalize_llm_response`` rejects the empty answer with
+    ``ValueError: Invalid response from LLM call - None or empty`` and the task dies
+    after its three built-in retries. Measured on a captured failing prompt, the
+    empties are *stochastic* (~40-60% per call on the worst prompts) and, counter-
+    intuitively, get worse with thinking disabled — so re-issuing the identical call
+    a handful of times reliably yields text. CrewAI deep-copies agent LLMs while
+    assembling crews, so this must patch the class, not an instance.
+
+    Provider-agnostic and cheap: a non-empty response returns on the first call, so
+    only genuine empties pay the retry cost. Tune the ceiling with ``LLM_EMPTY_RETRIES``
+    (default 6); set it to 0 to disable.
+    """
+    if getattr(LLM, "_retry_on_empty_patched", False):
+        return
+
+    original_call = LLM.call
+
+    def call(self: LLM, *args, **kwargs):
+        max_retries = int(os.getenv("LLM_EMPTY_RETRIES", "6"))
+        return _call_with_empty_retry(
+            lambda: original_call(self, *args, **kwargs),
+            max_retries,
+            getattr(self, "model", "?"),
+        )
+
+    LLM.call = call  # type: ignore[method-assign]
+    LLM._retry_on_empty_patched = True  # type: ignore[attr-defined]
+
+
 _patch_anthropic_detection_for_openrouter()
 _force_react_tool_calling()
+_patch_llm_retry_on_empty()
 
 
 class LLMConfig:

--- a/tests/config/test_llm_config_empty_retry.py
+++ b/tests/config/test_llm_config_empty_retry.py
@@ -1,0 +1,77 @@
+"""LLMConfig retries LLM.call when a provider returns empty content.
+
+gemini/gemini-3.5-flash intermittently returns a thought-only response on CrewAI
+ReAct steps (message.content is None with finish_reason=stop). CrewAI then raises
+"Invalid response from LLM call - None or empty" and the task dies after its three
+retries. The empties are stochastic, so re-issuing the identical call a few times
+yields text. These tests exercise the retry loop deterministically (no live calls)
+plus the emptiness predicate and confirm the class patch is applied.
+"""
+
+from crewai import LLM
+
+from epic_news.config.llm_config import (
+    _call_with_empty_retry,
+    _is_empty_llm_response,
+)
+
+
+def test_is_empty_llm_response_predicate():
+    assert _is_empty_llm_response(None) is True
+    assert _is_empty_llm_response("") is True
+    assert _is_empty_llm_response("   \n\t ") is True
+    assert _is_empty_llm_response("Final Answer: ok") is False
+    assert _is_empty_llm_response(0) is False  # a non-str truthy-ish value is not "empty text"
+
+
+def test_retry_returns_first_non_empty():
+    seq = iter(["", "  ", "Action: search"])
+    calls = {"n": 0}
+
+    def call_fn():
+        calls["n"] += 1
+        return next(seq)
+
+    result = _call_with_empty_retry(call_fn, max_retries=6, model="gemini/test")
+    assert result == "Action: search"
+    assert calls["n"] == 3  # two empties, then success
+
+
+def test_non_empty_first_call_does_not_retry():
+    calls = {"n": 0}
+
+    def call_fn():
+        calls["n"] += 1
+        return "immediate answer"
+
+    result = _call_with_empty_retry(call_fn, max_retries=6, model="m")
+    assert result == "immediate answer"
+    assert calls["n"] == 1  # returned on the first call, no retries
+
+
+def test_gives_up_after_max_retries_returns_last():
+    calls = {"n": 0}
+
+    def call_fn():
+        calls["n"] += 1
+        return ""  # always empty
+
+    result = _call_with_empty_retry(call_fn, max_retries=3, model="m")
+    assert result == ""  # returns the last (still empty) result for normal handling
+    assert calls["n"] == 4  # 1 initial + 3 retries
+
+
+def test_max_retries_zero_disables_retry():
+    calls = {"n": 0}
+
+    def call_fn():
+        calls["n"] += 1
+        return
+
+    result = _call_with_empty_retry(call_fn, max_retries=0, model="m")
+    assert result is None
+    assert calls["n"] == 1
+
+
+def test_llm_call_is_patched():
+    assert getattr(LLM, "_retry_on_empty_patched", False) is True


### PR DESCRIPTION
## Problem

`crewai flow kickoff` fails intermittently (e.g. `generate_shopping_advice`) with:

```
ValueError: Invalid response from LLM call - None or empty.
```

Root cause: **`gemini/gemini-3.5-flash` intermittently returns a thought-only response** on CrewAI ReAct steps. The generated tokens land in a thinking block carrying a `thought_signature`, so `message.content` comes back `None` while `finish_reason=stop` (it is *not* a length/budget cut-off). CrewAI's `_validate_and_finalize_llm_response` rejects the empty answer and the task dies after its 3 built-in retries, failing the whole flow. Which task hits it varies run-to-run — the empties are **stochastic**.

## Investigation (systematic debugging)

Measured on the exact captured failing prompt (5 reps each):

| variant | empty/5 |
|---|---|
| `reasoning_effort='none'` | 3/5 ❌ |
| `reasoning_effort='minimal'` | 3/5 ❌ |
| `reasoning_effort='low'` | 0/5 ✅ |
| default (thinking ON) | 0/5 ✅ |
| `mistral-small` (control) | 0/5 ✅ |

Key finding: **disabling thinking makes empties _worse_** — so an initial "default Gemini to `reasoning_effort=none`" idea was rejected (it increased failures). Thinking-ON still carries a residual stochastic empty (the originally-reported failure), which this PR handles.

## Fix

`_patch_llm_retry_on_empty()` patches `crewai.LLM.call` at the **class level** (survives CrewAI's agent-LLM deep-copy, like the existing anthropic/react patches) to re-issue the call when it returns empty/`None` content.

- Provider-agnostic and cheap: non-empty responses return on the first call, so only genuine empties pay the retry cost.
- Ceiling via `LLM_EMPTY_RETRIES` (default 6; set 0 to disable).
- Retry loop extracted to `_call_with_empty_retry` for deterministic unit testing.

## Verification

- **Unit:** 6 new tests + full `tests/config/` suite green (15 passed); contract suite green.
- **Live retry proof:** with empties forced (~50%), 7 retries fired → **0/12 empty**.
- **End-to-end:** full `ShoppingAdvisorCrew` run **completes 4/4 tasks** with valid `ShoppingAdviceOutput`.
- **mypy + ruff:** clean.

## Alternative

If Gemini is ever dropped, `MODEL=openrouter/mistralai/mistral-small-2603` was 0/5 with no patch needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when AI responses are empty or contain only whitespace by automatically retrying the request.
  * Returns the latest response after retry attempts are exhausted, preserving existing handling for unsuccessful results.

* **Tests**
  * Added coverage for retry behavior, including successful retries, exhausted attempts, disabled retries, and empty-response detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->