### PR TITLE
build: fully qualify base image names for Podman

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG PYTHON_IMAGE=python:3.13-slim-bookworm
+ARG PYTHON_IMAGE=docker.io/library/python:3.13-slim-bookworm
 
 # ---------------------------------------------------------------------------
 # builder — resolves and installs the venv. Never shipped.

--- a/Dockerfile.code-interpreter
+++ b/Dockerfile.code-interpreter
@@ -1,6 +1,6 @@
 
 # Use a specific, lightweight Python runtime as a base image for stability
-FROM python:3.12-slim-bookworm
+FROM docker.io/library/python:3.12-slim-bookworm
 
 # Set the working directory in the container
 WORKDIR /app


### PR DESCRIPTION
Preparation for the Docker→Podman move.

Podman resolves unqualified image names via `unqualified-search-registries` in `registries.conf`. On RHEL/Fedora that list does not start with `docker.io`, and under `short-name-mode="enforcing"` an unqualified name fails outright in a non-interactive build. Docker always implies `docker.io/library`.

Every base image is now fully qualified. Already-qualified refs (`ghcr.io/*`, `gcr.io/*`, `registry.access.redhat.com/*`), `FROM scratch`, and inter-stage `FROM <stage>` references are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container builds to use fully qualified Python image references.
  * Improved consistency and clarity when retrieving the Python base images from Docker Hub.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->